### PR TITLE
👌 IMP: Tweak exploration constant

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -22,7 +22,7 @@ const DEFAULT_MOVE_TIME_FRACTION: u32 = 15;
 pub const SCALE: f32 = 1e9;
 
 fn policy() -> AlphaGoPolicy {
-    AlphaGoPolicy::new(1.5 * SCALE)
+    AlphaGoPolicy::new(2.0 * SCALE)
 }
 
 pub struct GooseMCTS;


### PR DESCRIPTION
Tournament suggested 2.0 as the best factor. There is still tweaking that could be done in the future.

```
all_versions_1  | Rank Name                          Elo     +/-   Games   Score    Draw
all_versions_1  |    1 p20                           108      37     200   65.0%   43.0%
all_versions_1  |    2 p25                            70      35     200   60.0%   48.0%
all_versions_1  |    3 p30                            67      37     200   59.5%   41.0%
all_versions_1  |    4 p15                            47      36     200   56.8%   45.5%
all_versions_1  |    5 p10                           -58      37     200   41.8%   41.5%
all_versions_1  |    6 p05                          -275      47     200   17.0%   27.0%
```