### PR TITLE
📦 NEW: Use previous playouts to set root policy

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -292,9 +292,10 @@ where
         moves.sort_by_key(|(h, e)| FloatOrd(h.average_reward().unwrap_or(*e)));
         for (mov, e) in moves {
             println!(
-                "info string {} M: {:>6} V: {:7} E: {:>6} (cp {:>5})",
+                "info string {} M: {:>6} P: {:>6} V: {:7} E: {:>6} (cp {:>5})",
                 mov.get_move(),
                 format!("{:3.2}", e * 100.),
+                format!("{:3.2}", mov.move_evaluation() * 100.),
                 mov.visits(),
                 mov.average_reward()
                     .map_or("n/a".to_string(), |r| format!("{:3.2}", r / (SCALE / 100.))),


### PR DESCRIPTION
```
elo_test_1      | Score of Princhess 0.0.0-dev vs princhess-main: 436 - 288 - 325  [0.571] 1049
elo_test_1      | ...      Princhess 0.0.0-dev playing White: 223 - 148 - 154  [0.571] 525
elo_test_1      | ...      Princhess 0.0.0-dev playing Black: 213 - 140 - 171  [0.570] 524
elo_test_1      | ...      White vs Black: 363 - 361 - 325  [0.501] 1049
elo_test_1      | Elo difference: 49.3 +/- 17.6, LOS: 100.0 %, DrawRatio: 31.0 %
elo_test_1      | SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```