### PR TITLE
📦 NEW: Make exploration constant configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Princhess can be played against on Lichess at https://lichess.org/@/princhess_bo
 * **SyzygyPath** - Path to folder where the Syzygy tablebase files are.
   Currently only supports a single folder.
 
+* **ExplorationConstant** - Exploration constant used by PUCT. Defaults to 200.
 
 # Contributing
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,8 +1,10 @@
-use atomics::{AtomicUsize, Ordering};
+use atomics::{AtomicU64, AtomicUsize, Ordering};
 use std::cmp::max;
 
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(1);
 static HASH_SIZE_MB: AtomicUsize = AtomicUsize::new(16);
+
+static EXPLORATION_CONSTANT: AtomicU64 = AtomicU64::new(200);
 
 pub fn set_num_threads(threads: usize) {
     NUM_THREADS.store(threads, Ordering::Relaxed);
@@ -18,4 +20,12 @@ pub fn set_hash_size_mb(hs: usize) {
 
 pub fn get_hash_size_mb() -> usize {
     max(1, HASH_SIZE_MB.load(Ordering::Relaxed))
+}
+
+pub fn set_exploration_constant(c: usize) {
+    EXPLORATION_CONSTANT.store(c, Ordering::Relaxed);
+}
+
+pub fn get_exploration_constant() -> usize {
+    EXPLORATION_CONSTANT.load(Ordering::Relaxed)
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,7 +4,7 @@ use std::cmp::max;
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(1);
 static HASH_SIZE_MB: AtomicUsize = AtomicUsize::new(16);
 
-static EXPLORATION_CONSTANT: AtomicU64 = AtomicU64::new(200);
+static EXPLORATION_CONSTANT: AtomicU64 = AtomicU64::new(225);
 
 pub fn set_num_threads(threads: usize) {
     NUM_THREADS.store(threads, Ordering::Relaxed);

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,7 +7,7 @@ use float_ord::FloatOrd;
 use mcts::{
     AsyncSearchOwned, CycleBehaviour, Evaluator, GameState, MCTSManager, MoveInfoHandle, MCTS,
 };
-use options::get_num_threads;
+use options::{get_num_threads, get_exploration_constant};
 use policy_features::evaluate_single;
 use search_tree::{empty_previous_table, PreviousTable};
 use shakmaty_syzygy::Syzygy;
@@ -26,7 +26,8 @@ const DEFAULT_MOVE_TIME_FRACTION: u32 = 15;
 pub const SCALE: f32 = 1e9;
 
 fn policy() -> AlphaGoPolicy {
-    AlphaGoPolicy::new(2.0 * SCALE)
+    let c = get_exploration_constant() as f32 / 100.;
+    AlphaGoPolicy::new(c * SCALE)
 }
 
 pub struct GooseMCTS;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,4 +1,4 @@
-use options::{set_hash_size_mb, set_num_threads};
+use options::{set_exploration_constant, set_hash_size_mb, set_num_threads};
 use search::Search;
 use search_tree::empty_previous_table;
 use state::State;
@@ -41,28 +41,9 @@ pub fn main(commands: Vec<String>) {
                 "setoption"  => {
                     let option = UciOption::parse(tokens);
 
-                    match option {
-                        Some(opt) if opt.name() == "syzygypath" => {
-                            if let Some(path) = opt.value() {
-                                set_tablebase_directory(path)
-                            }
-                        }
-                        Some(opt) if opt.name() == "threads" => {
-                            if let Some(v) = opt.value() {
-                                if let Some(t) = v.parse().ok() {
-                                    set_num_threads(t)
-                                }
-                            }
-                        }
-                        Some(opt) if opt.name() == "hash" => {
-                            if let Some(v) = opt.value() {
-                                if let Some(t) = v.parse().ok() {
-                                    set_hash_size_mb(t)
-                                }
-                            }
-                        }
-                        _ => warn!("Badly formatted or unknown option"),
-                       }
+                    if let Some(opt) = option {
+                        opt.set();
+                    }
                 }
                 "ucinewgame" => {
                     search = Search::new(State::default(), empty_previous_table());
@@ -95,6 +76,7 @@ pub fn uci() {
     println!("option name Hash type spin min 1 max 65536 default 1");
     println!("option name Threads type spin min 1 max 255 default 1");
     println!("option name SyzygyPath type string");
+    println!("option name ExplorationConstant type spin min 1 max 65536 default 200");
     println!("uciok");
 }
 
@@ -140,6 +122,38 @@ impl UciOption {
 
     pub fn value(&self) -> &Option<String> {
         &self.value
+    }
+
+    pub fn set(&self) {
+        match self.name().as_str() {
+            "syzygypath" => {
+                if let Some(path) = self.value() {
+                    set_tablebase_directory(path)
+                }
+            }
+            "threads" => {
+                if let Some(v) = self.value() {
+                    if let Some(t) = v.parse().ok() {
+                        set_num_threads(t)
+                    }
+                }
+            }
+            "hash" => {
+                if let Some(v) = self.value() {
+                    if let Some(t) = v.parse().ok() {
+                        set_hash_size_mb(t)
+                    }
+                }
+            }
+            "explorationconstant" => {
+                if let Some(v) = self.value() {
+                    if let Some(t) = v.parse().ok() {
+                        set_exploration_constant(t)
+                    }
+                }
+            }
+            _ => warn!("Badly formatted or unknown option"),
+        }
     }
 }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -76,7 +76,7 @@ pub fn uci() {
     println!("option name Hash type spin min 1 max 65536 default 1");
     println!("option name Threads type spin min 1 max 255 default 1");
     println!("option name SyzygyPath type string");
-    println!("option name ExplorationConstant type spin min 1 max 65536 default 200");
+    println!("option name ExplorationConstant type spin min 1 max 65536 default 225");
     println!("uciok");
 }
 


### PR DESCRIPTION
No ELO loss from making it configurable
```
ELO   | 0.98 +- 7.85 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-10.00, -2.00]
GAMES | N: 5336 W: 1902 L: 1887 D: 1547
```

Slight ELO gain from defaulting to 225 instead of 200
```
ELO   | 13.96 +- 12.89 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 5.00]
GAMES | N: 1992 W: 749 L: 669 D: 574
```