### PR TITLE
🐛 FIX: Correct mate eval formula

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -525,12 +525,15 @@ impl<Spec: MCTS> SearchTree<Spec> {
         players: &[Player],
         evaln: &StateEvaluation<Spec>,
     ) {
+        let mut mate_decay = 0.01;
+
         for ((move_info, player), node) in
             path.iter().zip(players.iter()).zip(node_path.iter()).rev()
         {
             let mut evaln_value = self.eval.interpret_evaluation_for_player(evaln, player);
             if evaln_value.abs() > SCALE as i64 {
-                evaln_value -= evaln_value.signum() * (0.01 * SCALE) as i64;
+                evaln_value -= evaln_value.signum() * (mate_decay * SCALE) as i64;
+                mate_decay += 0.01;
             }
             node.up(&self.manager, evaln_value);
             move_info.hot.replace(*node);


### PR DESCRIPTION
```
ELO   | 0.99 +- 17.94 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=128MB
LLR   | 0.14 (-2.94, 2.94) [-5.00, -2.00]
GAMES | N: 1056 W: 389 L: 386 D: 281
```

Not a very long test, but this change should not affect elo.