### PR TITLE
📦  NEW: Simpler seldepth

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -230,12 +230,13 @@ where
 
         let nodes = self.tree().num_nodes();
         let depth = fastapprox::faster::ln(nodes as f32).round();
+        let sel_depth = self.principal_variation(64).len();
         let nps = nodes * 1000 / search_time_ms as usize;
 
         let info_str = format!(
             "info depth {} seldepth {} nodes {} nps {} tbhits {} score {} time {} pv{}",
             depth,
-            self.tree().max_depth(),
+            sel_depth,
             nodes,
             nps,
             self.tree().tb_hits(),

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -230,7 +230,10 @@ where
 
         let nodes = self.tree().num_nodes();
         let depth = fastapprox::faster::ln(nodes as f32).round();
-        let sel_depth = self.principal_variation(64).len();
+        let pv = self.principal_variation(64);
+        let sel_depth = pv.len();
+        let pv_string: String = pv.into_iter().map(|x| format!(" {}", to_uci(x))).collect();
+
         let nps = nodes * 1000 / search_time_ms as usize;
 
         let info_str = format!(
@@ -242,16 +245,9 @@ where
             self.tree().tb_hits(),
             self.eval_in_cp(),
             search_time_ms,
-            self.get_pv()
+            pv_string,
         );
         println!("{}", info_str);
-    }
-
-    fn get_pv(&self) -> String {
-        self.principal_variation(10)
-            .into_iter()
-            .map(|x| format!(" {}", to_uci(x)))
-            .collect()
     }
 
     pub fn print_move_list(&self) {

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -29,7 +29,6 @@ pub struct SearchTree<Spec: MCTS> {
     arena: Box<Arena>,
 
     num_nodes: AtomicUsize,
-    max_depth: AtomicUsize,
     tb_hits: AtomicUsize,
     transposition_table_hits: AtomicUsize,
     delayed_transposition_table_hits: AtomicUsize,
@@ -289,7 +288,6 @@ impl<Spec: MCTS> SearchTree<Spec> {
             table,
             prev_table,
             num_nodes: 1.into(),
-            max_depth: 1.into(),
             tb_hits,
             arena,
             transposition_table_hits: 0.into(),
@@ -311,10 +309,6 @@ impl<Spec: MCTS> SearchTree<Spec> {
 
     pub fn num_nodes(&self) -> usize {
         self.num_nodes.load(Ordering::SeqCst)
-    }
-
-    pub fn max_depth(&self) -> usize {
-        self.max_depth.load(Ordering::SeqCst)
     }
 
     pub fn tb_hits(&self) -> usize {
@@ -471,8 +465,6 @@ impl<Spec: MCTS> SearchTree<Spec> {
             return Ok((existing, false));
         }
         self.num_nodes.fetch_add(1, Ordering::Relaxed);
-        let depth = path.len();
-        self.max_depth.fetch_max(depth, Ordering::Relaxed);
         Ok((created, did_we_create))
     }
 


### PR DESCRIPTION
```
ELO   | 1.25 +- 6.46 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-7.50, -1.50]
GAMES | N: 8890 W: 3582 L: 3550 D: 1758
```