### PR TITLE
📦 NEW: Only track repetition count of current position

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -160,13 +160,11 @@ impl State {
     }
     fn check_for_repetition(&mut self) {
         let crnt_hash = self.board.get_hash();
-        self.repetitions = max(
-            self.repetitions,
-            self.prev_state_hashes
-                .iter()
-                .filter(|h| **h == crnt_hash)
-                .count(),
-        );
+        self.repetitions = self
+            .prev_state_hashes
+            .iter()
+            .filter(|h| **h == crnt_hash)
+            .count();
     }
 
     fn drawn_by_fifty_move_rule(&self) -> bool {


### PR DESCRIPTION
```
ELO   | 7.37 +- 9.34 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=128MB
LLR   | 2.94 (-2.94, 2.94) [-7.50, -1.50]
GAMES | N: 4197 W: 1704 L: 1615 D: 878
```