### PR TITLE
📦 NEW: Remove cpuct base and factor. Tune CPuct

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@ Princhess can be played against on Lichess at https://lichess.org/@/princhess_bo
 * **SyzygyPath** - Path to folder where the Syzygy tablebase files are.
   Currently only supports a single folder.
 
-* **CPuct** - Exploration constant used by PUCT. Defaults to 2.15
-
-* **CPuctBase** - Base for PUCT growth formula. Defaults to 18368.
-
-* **CPuctFactor** - Multipler for the PUCT growth formula. Defaults to 2.82
+* **CPuct** - Exploration constant used by PUCT. Defaults to 1.79
 
 # Contributing
 

--- a/bin/Dockerfile.tune
+++ b/bin/Dockerfile.tune
@@ -14,7 +14,7 @@ RUN git clone https://github.com/cutechess/cutechess.git \
 
 RUN cp cutechess/build/cutechess-cli /usr/local/bin/cutechess-cli
 
-RUN pip3 install chess-tuning-tools
+RUN pip3 install chess-tuning-tools==0.8.3
 
 RUN mkdir /books
 RUN mkdir /engines

--- a/bin/tuning_config.json
+++ b/bin/tuning_config.json
@@ -20,15 +20,6 @@
   "parameter_ranges": {
     "CPuct": "Real(0.0, 5.0)"
   },
-  "_parameter_ranges": {
-    "CPuct": "Real(0.0, 5.0)",
-    "CPuctBase": "Integer(0, 65536)",
-    "CPuctFactor": "Real(0.0, 5.0)",
-    "PolicySoftmaxTemp": "Real(0.0, 2.0)",
-    "MateScore": "Real(1.0, 2.0)",
-    "PolicyGoodCaptureFactor": "Real(0.0, 5.0)",
-    "PolicyBadCaptureFactor": "Real(0.0, 5.0)"
-  },
   "engine1_tc": "10+0.1",
   "engine2_tc": "10+0.1",
   "timemargin": 1000,
@@ -37,8 +28,9 @@
   "adjudicate_resign": false,
   "adjudicate_tb": false,
   "concurrency": 6,
+  "plot_every": 10,
   "result_every": 10,
-  "acq_function": "ts"
+  "acq_function": "mes"
 }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       -openings file=/books/4moves_noob.epd format=epd order=random
       -games 2 -repeat -rounds 10000
       -recover -ratinginterval 10 -concurrency 6
+    volumes:
+      - ./target/release/princhess:/engines/princhess
+      - ./target/release/princhess-main:/engines/princhess-main
+      - ./syzygy:/syzygy:ro
+
 
   sprt_equal:
     build:
@@ -38,7 +43,6 @@ services:
       -openings file=/books/4moves_noob.epd format=epd order=random
       -games 2 -repeat -rounds 10000
       -recover -ratinginterval 10 -concurrency 6
-
     volumes:
       - ./target/release/princhess:/engines/princhess
       - ./target/release/princhess-main:/engines/princhess-main

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,14 +1,12 @@
 use once_cell::sync::Lazy;
 use std::cmp::max;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::RwLock;
 
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(1);
 static HASH_SIZE_MB: AtomicUsize = AtomicUsize::new(16);
 
-static CPUCT: Lazy<RwLock<f32>> = Lazy::new(|| RwLock::new(2.15));
-static CPUCT_BASE: AtomicU64 = AtomicU64::new(18368);
-static CPUCT_FACTOR: Lazy<RwLock<f32>> = Lazy::new(|| RwLock::new(2.82));
+static CPUCT: Lazy<RwLock<f32>> = Lazy::new(|| RwLock::new(1.79));
 
 pub fn set_num_threads(threads: usize) {
     NUM_THREADS.store(threads, Ordering::Relaxed);
@@ -34,22 +32,4 @@ pub fn set_cpuct(c: f32) {
 pub fn get_cpuct() -> f32 {
     let cp = CPUCT.read().unwrap();
     *cp
-}
-
-pub fn set_cpuct_base(c: u64) {
-    CPUCT_BASE.store(c, Ordering::Relaxed);
-}
-
-pub fn get_cpuct_base() -> u64 {
-    CPUCT_BASE.load(Ordering::Relaxed)
-}
-
-pub fn set_cpuct_factor(c: f32) {
-    let mut cf = CPUCT_FACTOR.write().unwrap();
-    *cf = c;
-}
-
-pub fn get_cpuct_factor() -> f32 {
-    let cf = CPUCT_FACTOR.read().unwrap();
-    *cf
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -5,7 +5,7 @@ use features::Model;
 use mcts::{
     AsyncSearchOwned, CycleBehaviour, Evaluator, GameState, MCTSManager, MoveInfoHandle, MCTS,
 };
-use options::{get_cpuct, get_cpuct_base, get_cpuct_factor, get_num_threads};
+use options::{get_cpuct, get_num_threads};
 use search_tree::{empty_previous_table, PreviousTable};
 use state::{Move, State, StateBuilder};
 use std::sync::atomic::Ordering;
@@ -24,10 +24,8 @@ pub const SCALE: f32 = 1e9;
 
 fn policy() -> AlphaGoPolicy {
     let cpuct = get_cpuct();
-    let cpuct_base = get_cpuct_base() as f32;
-    let cpuct_factor = get_cpuct_factor();
 
-    AlphaGoPolicy::new(cpuct * SCALE, cpuct_base, cpuct_factor * SCALE)
+    AlphaGoPolicy::new(cpuct * SCALE)
 }
 
 pub struct GooseMCTS;

--- a/src/tree_policy.rs
+++ b/src/tree_policy.rs
@@ -31,17 +31,11 @@ pub trait TreePolicy<Spec: MCTS<TreePolicy = Self>>: Sync + Sized {
 #[derive(Clone, Debug)]
 pub struct AlphaGoPolicy {
     cpuct: f32,
-    cpuct_base: f32,
-    cpuct_factor: f32,
 }
 
 impl AlphaGoPolicy {
-    pub fn new(cpuct: f32, cpuct_base: f32, cpuct_factor: f32) -> Self {
-        Self {
-            cpuct,
-            cpuct_base,
-            cpuct_factor,
-        }
+    pub fn new(cpuct: f32) -> Self {
+        Self { cpuct }
     }
 }
 
@@ -56,9 +50,7 @@ impl<Spec: MCTS<TreePolicy = Self>> TreePolicy<Spec> for AlphaGoPolicy {
     ) -> MoveInfoHandle<'a> {
         let total_visits = moves.map(|x| x.visits()).sum::<u64>() + 1;
         let sqrt_total_visits = (total_visits as f32).sqrt();
-        let exploration_constant = self.cpuct
-            + self.cpuct_factor
-                * ((total_visits as f32 + self.cpuct_base + 1.0) / self.cpuct_base).ln();
+        let exploration_constant = self.cpuct;
 
         let explore_coef = exploration_constant * sqrt_total_visits;
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,4 +1,4 @@
-use options::{set_cpuct, set_cpuct_base, set_cpuct_factor, set_hash_size_mb, set_num_threads};
+use options::{set_cpuct, set_hash_size_mb, set_num_threads};
 use search::Search;
 use search_tree::{empty_previous_table, print_size_list};
 use state::State;
@@ -78,9 +78,7 @@ pub fn uci() {
     println!("option name Hash type spin min 8 max 65536 default 16");
     println!("option name Threads type spin min 1 max 255 default 1");
     println!("option name SyzygyPath type string");
-    println!("option name CPuct type string default 2.15");
-    println!("option name CPuctBase type spin min 1 max 65536 default 18368");
-    println!("option name CPuctFactor type string default 2.82");
+    println!("option name CPuct type string default 1.79");
 
     println!("uciok");
 }
@@ -139,8 +137,6 @@ impl UciOption {
             "threads" => self.set_option(set_num_threads),
             "hash" => self.set_option(set_hash_size_mb),
             "cpuct" => self.set_option(set_cpuct),
-            "cpuctbase" => self.set_option(set_cpuct_base),
-            "cpuctfactor" => self.set_option(set_cpuct_factor),
             _ => warn!("Badly formatted or unknown option"),
         }
     }


### PR DESCRIPTION
```
 Score of princhess vs princhess-main: 1250 - 1134 - 742  [0.519] 3126
 ...      princhess playing White: 632 - 569 - 361  [0.520] 1562
 ...      princhess playing Black: 618 - 565 - 381  [0.517] 1564
 ...      White vs Black: 1197 - 1187 - 742  [0.502] 3126
 Elo difference: 12.9 +/- 10.6, LOS: 99.1 %, DrawRatio: 23.7 %
 SPRT: llr 2.97 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```