### PR TITLE
👌 IMP: Remove State#freeze

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -81,7 +81,7 @@ impl Search {
         prev_table: PreviousTable<GooseMCTS>,
     ) -> MCTSManager<GooseMCTS> {
         MCTSManager::new(
-            state.freeze(),
+            state,
             GooseMCTS,
             GooseEval::new(Model::new()),
             policy(),
@@ -298,7 +298,7 @@ impl Search {
             let state: State = StateBuilder::from_fen(fen).unwrap().into();
 
             let manager = MCTSManager::new(
-                state.freeze(),
+                state,
                 GooseMCTS,
                 GooseEval::new(Model::new()),
                 policy(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -101,7 +101,6 @@ pub struct State {
     prev_capture_sq: Option<shakmaty::Square>,
     prev_state_hashes: SmallVec<[u64; 64]>,
     repetitions: usize,
-    frozen: bool,
     outcome: Outcome,
 }
 impl State {
@@ -168,13 +167,6 @@ impl State {
 
     fn drawn_by_repetition(&self) -> bool {
         self.repetitions >= 2
-    }
-
-    pub fn freeze(self) -> Self {
-        Self {
-            frozen: true,
-            ..self
-        }
     }
 
     pub fn feature_flip(&self) -> (bool, bool) {
@@ -327,7 +319,6 @@ impl From<StateBuilder> for State {
             prev_capture_sq: None,
             prev_state_hashes: SmallVec::new(),
             repetitions: 0,
-            frozen: false,
             outcome: Outcome::Ongoing,
         };
 
@@ -423,9 +414,8 @@ impl GameState for State {
         .0 != 0;
         if is_pawn_move || self.prev_capture.is_some() {
             self.prev_state_hashes.clear();
-        } else if !self.frozen {
-            self.prev_state_hashes.push(self.board.get_hash());
         }
+        self.prev_state_hashes.push(self.board.get_hash());
         self.prev_move = Some(*mov);
 
         let shakmaty_move = shakmaty::uci::Uci::from_ascii(to_uci(*mov).as_bytes())


### PR DESCRIPTION
```
 Score of princhess vs princhess-main: 1262 - 1224 - 942  [0.506] 3428
 ...      princhess playing White: 591 - 627 - 497  [0.490] 1715
 ...      princhess playing Black: 671 - 597 - 445  [0.522] 1713
 ...      White vs Black: 1188 - 1298 - 942  [0.484] 3428
 Elo difference: 3.9 +/- 9.9, LOS: 77.7 %, DrawRatio: 27.5 %
 SPRT: llr 2.97 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```