### PR TITLE
📦 NEW: Unify NN::get_input and get_output

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -69,10 +69,9 @@ impl Model {
         Model
     }
     pub fn predict(&self, state: &State, features: &[f32; state::NUMBER_FEATURES]) -> f32 {
-        let mut nn = NN::new();
-        nn.set_inputs(features);
+        let nn = NN::new();
 
-        let mut result = nn.get_output();
+        let mut result = nn.get_output(features);
 
         result = result.tanh();
 

--- a/src/nn.rs
+++ b/src/nn.rs
@@ -15,36 +15,34 @@ const EVAL_HIDDEN_WEIGHTS: [[f32; NUMBER_INPUTS]; NUMBER_HIDDEN] =
 const EVAL_OUTPUT_WEIGHTS: [[f32; NUMBER_HIDDEN]; NUMBER_OUTPUTS] =
     include!("model/output_weights");
 
-pub struct NN {
-    hidden_layer: [f32; NUMBER_HIDDEN],
-}
+pub struct NN;
 
 impl NN {
     pub fn new() -> Self {
-        #[allow(clippy::uninit_assumed_init)]
-        let hidden_layer = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-        Self { hidden_layer }
+        Self
     }
 
-    pub fn set_inputs(&mut self, inputs: &[f32; state::NUMBER_FEATURES]) {
-        self.hidden_layer.copy_from_slice(&EVAL_HIDDEN_BIAS);
+    pub fn get_output(&self, inputs: &[f32; state::NUMBER_FEATURES]) -> f32 {
+        #[allow(clippy::uninit_assumed_init)]
+        let mut hidden_layer: [f32; NUMBER_HIDDEN] =
+            unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+
+        hidden_layer.copy_from_slice(&EVAL_HIDDEN_BIAS);
 
         for i in 0..inputs.len() {
             if inputs[i] > 0.5 {
-                for j in 0..self.hidden_layer.len() {
-                    self.hidden_layer[j] += EVAL_HIDDEN_WEIGHTS[j][i];
+                for j in 0..hidden_layer.len() {
+                    hidden_layer[j] += EVAL_HIDDEN_WEIGHTS[j][i];
                 }
             }
         }
-    }
 
-    pub fn get_output(&self) -> f32 {
         let mut result = 0.;
 
         let weights = EVAL_OUTPUT_WEIGHTS[0];
 
-        for i in 0..self.hidden_layer.len() {
-            result += weights[i] * self.hidden_layer[i].max(0.);
+        for i in 0..hidden_layer.len() {
+            result += weights[i] * hidden_layer[i].max(0.);
         }
 
         result


### PR DESCRIPTION
```
 Score of princhess vs princhess-main: 3002 - 3025 - 1410  [0.498] 7437
 ...      princhess playing White: 1469 - 1562 - 688  [0.487] 3719
 ...      princhess playing Black: 1533 - 1463 - 722  [0.509] 3718
 ...      White vs Black: 2932 - 3095 - 1410  [0.489] 7437
 Elo difference: -1.1 +/- 7.1, LOS: 38.4 %, DrawRatio: 19.0 %
 SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```