### PR TITLE
👌 IMP: Remove Evaluator trait and GooseEval

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -1,7 +1,7 @@
 use chess::*;
 use math;
-use mcts::{Evaluator, GameState};
-use search::{GooseMcts, SCALE};
+use mcts::GameState;
+use search::SCALE;
 use shakmaty::Position;
 use shakmaty_syzygy::Wdl;
 use state::{self, MoveList, Player, State};
@@ -11,50 +11,40 @@ use tablebase::probe_tablebase_wdl;
 
 const MATE_FACTOR: f32 = 1.1;
 
-pub struct GooseEval;
-
-impl GooseEval {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Evaluator<GooseMcts> for GooseEval {
-    fn evaluate_new_state(&self, state: &State, moves: &MoveList) -> (Vec<f32>, i64, bool) {
-        let features = state.features();
-        let move_evaluations = evaluate_policy(state, &features, moves);
-        let mut tb_hit = false;
-        let state_evaluation = if moves.is_empty() {
-            let x = (MATE_FACTOR * SCALE) as i64;
-            if state.shakmaty_board().is_check() {
-                match state.current_player() {
-                    chess::Color::White => -x,
-                    chess::Color::Black => x,
-                }
-            } else {
-                0
-            }
-        } else if let Some(wdl) = probe_tablebase_wdl(state.shakmaty_board()) {
-            tb_hit = true;
-            let win_score = SCALE as i64;
-            match (wdl, state.board().side_to_move()) {
-                (Wdl::Win, Color::White) => win_score,
-                (Wdl::Loss, Color::White) => -win_score,
-                (Wdl::Win, Color::Black) => -win_score,
-                (Wdl::Loss, Color::Black) => win_score,
-                _ => 0,
+pub fn evaluate_new_state(state: &State, moves: &MoveList) -> (Vec<f32>, i64, bool) {
+    let features = state.features();
+    let move_evaluations = evaluate_policy(state, &features, moves);
+    let mut tb_hit = false;
+    let state_evaluation = if moves.is_empty() {
+        let x = (MATE_FACTOR * SCALE) as i64;
+        if state.shakmaty_board().is_check() {
+            match state.current_player() {
+                chess::Color::White => -x,
+                chess::Color::Black => x,
             }
         } else {
-            (evaluate_state(state, &features) * SCALE) as i64
-        };
-        (move_evaluations, state_evaluation, tb_hit)
-    }
-
-    fn interpret_evaluation_for_player(&self, evaln: &i64, player: &Player) -> i64 {
-        match *player {
-            Color::White => *evaln,
-            Color::Black => -*evaln,
+            0
         }
+    } else if let Some(wdl) = probe_tablebase_wdl(state.shakmaty_board()) {
+        tb_hit = true;
+        let win_score = SCALE as i64;
+        match (wdl, state.board().side_to_move()) {
+            (Wdl::Win, Color::White) => win_score,
+            (Wdl::Loss, Color::White) => -win_score,
+            (Wdl::Win, Color::Black) => -win_score,
+            (Wdl::Loss, Color::Black) => win_score,
+            _ => 0,
+        }
+    } else {
+        (evaluate_state(state, &features) * SCALE) as i64
+    };
+    (move_evaluations, state_evaluation, tb_hit)
+}
+
+pub fn interpret_evaluation_for_player(evaln: &i64, player: &Player) -> i64 {
+    match *player {
+        Color::White => *evaln,
+        Color::Black => -*evaln,
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,6 +1,5 @@
 use bench::BENCHMARKING_POSITIONS;
 use chess::Color;
-use evaluation::GooseEval;
 use mcts::{AsyncSearchOwned, GameState, Mcts, MctsManager, MoveInfoHandle};
 use options::{get_cpuct, get_num_threads};
 use search_tree::{empty_previous_table, PreviousTable};
@@ -41,7 +40,6 @@ impl Drop for ThreadSentinel {
 }
 
 impl Mcts for GooseMcts {
-    type Eval = GooseEval;
     type TreePolicy = AlphaGoPolicy;
     type ExtraThreadData = ThreadSentinel;
     type TranspositionTable = ApproxTable;
@@ -77,7 +75,6 @@ impl Search {
         MctsManager::new(
             state,
             GooseMcts,
-            GooseEval::new(),
             policy(),
             ApproxTable::enough_to_hold(GooseMcts.node_limit()),
             prev_table,
@@ -271,7 +268,6 @@ impl Search {
             let manager = MctsManager::new(
                 state,
                 GooseMcts,
-                GooseEval::new(),
                 policy(),
                 ApproxTable::enough_to_hold(GooseMcts.node_limit()),
                 empty_previous_table(),


### PR DESCRIPTION
```
 Score of princhess vs princhess-main: 2408 - 2416 - 1471  [0.499] 6295
 ...      princhess playing White: 1191 - 1220 - 737  [0.495] 3148
 ...      princhess playing Black: 1217 - 1196 - 734  [0.503] 3147
 ...      White vs Black: 2387 - 2437 - 1471  [0.496] 6295
 Elo difference: -0.4 +/- 7.5, LOS: 45.4 %, DrawRatio: 23.4 %
 SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```