### PR TITLE
👌 IMP: Iterate over occupied for features

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -170,12 +170,15 @@ impl State {
             (false, false) => sq,
         };
 
-        for (sq, pc) in b.pieces() {
+        for sq in b.occupied() {
+            let role = b.role_at(sq).unwrap();
+            let color = b.color_at(sq).unwrap();
+
             let adj_sq = flip_square(sq);
 
             let sq_idx = adj_sq as usize;
-            let role_idx = pc.role as usize - 1;
-            let side_idx = usize::from(pc.color != stm);
+            let role_idx = role as usize - 1;
+            let side_idx = usize::from(color != stm);
 
             let feature_idx = (side_idx * 6 + role_idx) * 64 + sq_idx;
 


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 1335 - 1290 - 755  [0.507] 3380
princhess-sprt_equal-1  | ...      princhess playing White: 656 - 650 - 385  [0.502] 1691
princhess-sprt_equal-1  | ...      princhess playing Black: 679 - 640 - 370  [0.512] 1689
princhess-sprt_equal-1  | ...      White vs Black: 1296 - 1329 - 755  [0.495] 3380
princhess-sprt_equal-1  | Elo difference: 4.6 +/- 10.3, LOS: 81.0 %, DrawRatio: 22.3 %
princhess-sprt_equal-1  | SPRT: llr 2.94 (99.9%), lbound -2.94, ubound 2.94
```