### PR TITLE
👌 IMP: Check max_pieces before tablebase probe

### DIFF
--- a/src/tablebase.rs
+++ b/src/tablebase.rs
@@ -1,7 +1,7 @@
 use arc_swap::ArcSwap;
 use log::debug;
 use once_cell::sync::Lazy;
-use shakmaty::{Chess, Move};
+use shakmaty::{Chess, Move, Setup};
 use shakmaty_syzygy::{Tablebase, Wdl};
 use std::path::Path;
 use std::sync::Arc;
@@ -17,12 +17,22 @@ pub fn set_tablebase_directory<P: AsRef<Path>>(path: P) {
 }
 
 pub fn probe_tablebase_wdl(pos: &Chess) -> Option<Wdl> {
-    TABLEBASE.load().probe_wdl_after_zeroing(pos).ok()
+    let tb = TABLEBASE.load();
+    if pos.board().occupied().count() > tb.max_pieces() {
+        None
+    } else {
+        tb.probe_wdl_after_zeroing(pos).ok()
+    }
 }
 
 pub fn probe_tablebase_best_move(pos: &Chess) -> Option<Move> {
-    match TABLEBASE.load().best_move(pos) {
-        Ok(Some((m, _))) => Some(m),
-        _ => None,
+    let tb = TABLEBASE.load();
+    if pos.board().occupied().count() > tb.max_pieces() {
+        None
+    } else {
+        match tb.best_move(pos) {
+            Ok(Some((m, _))) => Some(m),
+            _ => None,
+        }
     }
 }


### PR DESCRIPTION
With syzygy tables:
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 672 - 609 - 551  [0.517] 1832
princhess-sprt_equal-1  | ...      princhess playing White: 347 - 308 - 261  [0.521] 916
princhess-sprt_equal-1  | ...      princhess playing Black: 325 - 301 - 290  [0.513] 916
princhess-sprt_equal-1  | ...      White vs Black: 648 - 633 - 551  [0.504] 1832
princhess-sprt_equal-1  | Elo difference: 12.0 +/- 13.3, LOS: 96.1 %, DrawRatio: 30.1 %
princhess-sprt_equal-1  | SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
```

Without syzygypath set:
```
princhess-sprt_gain-1  | Score of princhess vs princhess-main: 1075 - 973 - 1039  [0.517] 3087
princhess-sprt_gain-1  | ...      princhess playing White: 536 - 485 - 521  [0.517] 1542
princhess-sprt_gain-1  | ...      princhess playing Black: 539 - 488 - 518  [0.517] 1545
princhess-sprt_gain-1  | ...      White vs Black: 1024 - 1024 - 1039  [0.500] 3087
princhess-sprt_gain-1  | Elo difference: 11.5 +/- 10.0, LOS: 98.8 %, DrawRatio: 33.7 %
princhess-sprt_gain-1  | SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```