### PR TITLE
👌 IMP: Remove extra thread data

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -17,7 +17,6 @@ use std::time::Instant;
 pub trait Mcts: Sized + Sync {
     type TreePolicy: TreePolicy<Self>;
     type TranspositionTable: TranspositionTable;
-    type ExtraThreadData;
 
     /// Virtual loss subtracted from a node's evaluation when a search thread chooses it in a playout,
     /// then added back when the playout is complete.
@@ -42,19 +41,16 @@ pub trait Mcts: Sized + Sync {
 
 pub struct ThreadData<'a, Spec: Mcts> {
     pub policy_data: TreePolicyThreadData<Spec>,
-    pub extra_data: Spec::ExtraThreadData,
     pub allocator: ArenaAllocator<'a>,
 }
 
 impl<'a, Spec: Mcts> ThreadData<'a, Spec>
 where
     TreePolicyThreadData<Spec>: Default,
-    Spec::ExtraThreadData: Default,
 {
     fn create(tree: &'a SearchTree<Spec>) -> Self {
         Self {
             policy_data: Default::default(),
-            extra_data: Default::default(),
             allocator: tree.arena().allocator(),
         }
     }
@@ -73,7 +69,6 @@ pub struct MctsManager<Spec: Mcts> {
 impl<Spec: Mcts> MctsManager<Spec>
 where
     TreePolicyThreadData<Spec>: Default,
-    Spec::ExtraThreadData: Default,
 {
     pub fn new(
         state: State,

--- a/src/search.rs
+++ b/src/search.rs
@@ -25,23 +25,9 @@ fn policy() -> AlphaGoPolicy {
 }
 
 pub struct GooseMcts;
-pub struct ThreadSentinel;
-
-impl Default for ThreadSentinel {
-    fn default() -> Self {
-        info!("Search thread created.");
-        ThreadSentinel
-    }
-}
-impl Drop for ThreadSentinel {
-    fn drop(&mut self) {
-        info!("Search thread destroyed.");
-    }
-}
 
 impl Mcts for GooseMcts {
     type TreePolicy = AlphaGoPolicy;
-    type ExtraThreadData = ThreadSentinel;
     type TranspositionTable = ApproxTable;
 
     fn node_limit(&self) -> usize {


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 1915 - 1919 - 1677  [0.500] 5511
princhess-sprt_equal-1  | ...      princhess playing White: 962 - 947 - 847  [0.503] 2756
princhess-sprt_equal-1  | ...      princhess playing Black: 953 - 972 - 830  [0.497] 2755
princhess-sprt_equal-1  | ...      White vs Black: 1934 - 1900 - 1677  [0.503] 5511
princhess-sprt_equal-1  | Elo difference: -0.3 +/- 7.6, LOS: 47.4 %, DrawRatio: 30.4 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```