### PR TITLE
👌 IMP: Remove TransitionTable trait

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -16,7 +16,6 @@ use std::time::Instant;
 
 pub trait Mcts: Sized + Sync {
     type TreePolicy: TreePolicy<Self>;
-    type TranspositionTable: TranspositionTable;
 
     /// Virtual loss subtracted from a node's evaluation when a search thread chooses it in a playout,
     /// then added back when the playout is complete.
@@ -74,8 +73,8 @@ where
         state: State,
         manager: Spec,
         tree_policy: Spec::TreePolicy,
-        table: Spec::TranspositionTable,
-        prev_table: PreviousTable<Spec>,
+        table: ApproxTable,
+        prev_table: PreviousTable,
     ) -> Self {
         let search_tree = SearchTree::new(state, manager, tree_policy, table, prev_table);
         Self {
@@ -154,7 +153,7 @@ where
         &self.search_tree
     }
 
-    pub fn table(self) -> PreviousTable<Spec> {
+    pub fn table(self) -> PreviousTable {
         self.search_tree.table()
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -28,7 +28,6 @@ pub struct GooseMcts;
 
 impl Mcts for GooseMcts {
     type TreePolicy = AlphaGoPolicy;
-    type TranspositionTable = ApproxTable;
 
     fn node_limit(&self) -> usize {
         4_000_000
@@ -54,10 +53,7 @@ pub struct Search {
 }
 
 impl Search {
-    pub fn create_manager(
-        state: State,
-        prev_table: PreviousTable<GooseMcts>,
-    ) -> MctsManager<GooseMcts> {
+    pub fn create_manager(state: State, prev_table: PreviousTable) -> MctsManager<GooseMcts> {
         MctsManager::new(
             state,
             GooseMcts,
@@ -67,12 +63,12 @@ impl Search {
         )
     }
 
-    pub fn new(state: State, prev_table: PreviousTable<GooseMcts>) -> Self {
+    pub fn new(state: State, prev_table: PreviousTable) -> Self {
         let search = Self::create_manager(state, prev_table).into();
         Self { search }
     }
 
-    pub fn table(self) -> PreviousTable<GooseMcts> {
+    pub fn table(self) -> PreviousTable {
         let manager = self.stop_and_print_m();
         manager.table()
     }


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 910 - 863 - 813  [0.509] 2586
princhess-sprt_equal-1  | ...      princhess playing White: 453 - 436 - 404  [0.507] 1293
princhess-sprt_equal-1  | ...      princhess playing Black: 457 - 427 - 409  [0.512] 1293
princhess-sprt_equal-1  | ...      White vs Black: 880 - 893 - 813  [0.497] 2586
princhess-sprt_equal-1  | Elo difference: 6.3 +/- 11.1, LOS: 86.8 %, DrawRatio: 31.4 %
princhess-sprt_equal-1  | SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```