### PR TITLE
👌 IMP: Upgrade shakmaty to 0.20.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "shakmaty"
-version = "0.20.1"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4686eb3a4abc9e72cbd9a71cb385097e2d44800138dd3c099084bb5013922b5f"
+checksum = "e94edaf1bdad19647ee48ee17b232043107b39c41eaf73e46e95223c15e94590"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ pretty_env_logger = "=0.4.0"
 pod = "=0.5.0"
 pgn-reader = "=0.19.0"
 rand = { version = "=0.7.3", features = ["small_rng"] }
-shakmaty = "=0.20.1"
+shakmaty = "=0.20.7"
 shakmaty-syzygy = "=0.18.0"
 slurp = "=1.0.1"
 smallvec = "=0.6.14"


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 3128 - 3190 - 2539  [0.496] 8857
princhess-sprt_equal-1  | ...      princhess playing White: 1555 - 1596 - 1278  [0.495] 4429
princhess-sprt_equal-1  | ...      princhess playing Black: 1573 - 1594 - 1261  [0.498] 4428
princhess-sprt_equal-1  | ...      White vs Black: 3149 - 3169 - 2539  [0.499] 8857
princhess-sprt_equal-1  | Elo difference: -2.4 +/- 6.1, LOS: 21.8 %, DrawRatio: 28.7 %
princhess-sprt_equal-1  | SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```