### PR TITLE
👌 IMP: Use arrayvec instead of smallvec during playouts

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -32,10 +32,6 @@ pub trait Mcts: Sized + Sync {
     fn select_child_after_search<'a>(&self, children: &[MoveInfoHandle<'a>]) -> MoveInfoHandle<'a> {
         *children.iter().max_by_key(|child| child.visits()).unwrap()
     }
-    /// `playout` panics when this length is exceeded. Defaults to one million.
-    fn max_playout_length(&self) -> usize {
-        1_000_000
-    }
 }
 
 pub struct ThreadData<'a, Spec: Mcts> {


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 710 - 642 - 478  [0.519] 1830
princhess-sprt_equal-1  | ...      princhess playing White: 349 - 320 - 247  [0.516] 916
princhess-sprt_equal-1  | ...      princhess playing Black: 361 - 322 - 231  [0.521] 914
princhess-sprt_equal-1  | ...      White vs Black: 671 - 681 - 478  [0.497] 1830
princhess-sprt_equal-1  | Elo difference: 12.9 +/- 13.7, LOS: 96.8 %, DrawRatio: 26.1 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```