### PR TITLE
👌 IMP: Refactor to TranspotitionTable struct

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -70,7 +70,7 @@ where
         manager: Spec,
         tree_policy: Spec::TreePolicy,
         table: ApproxTable,
-        prev_table: PreviousTable,
+        prev_table: TranspositionTable,
     ) -> Self {
         let search_tree = SearchTree::new(state, manager, tree_policy, table, prev_table);
         Self {
@@ -149,7 +149,7 @@ where
         &self.search_tree
     }
 
-    pub fn table(self) -> PreviousTable {
+    pub fn table(self) -> TranspositionTable {
         self.search_tree.table()
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,7 @@
 use bench::BENCHMARKING_POSITIONS;
 use mcts::{AsyncSearchOwned, Mcts, MctsManager, MoveInfoHandle};
 use options::{get_cpuct, get_num_threads};
-use search_tree::{empty_previous_table, PreviousTable};
+use search_tree::TranspositionTable;
 use shakmaty::{Color, Move};
 use state::{State, StateBuilder};
 use std::sync::atomic::Ordering;
@@ -53,7 +53,7 @@ pub struct Search {
 }
 
 impl Search {
-    pub fn create_manager(state: State, prev_table: PreviousTable) -> MctsManager<GooseMcts> {
+    pub fn create_manager(state: State, prev_table: TranspositionTable) -> MctsManager<GooseMcts> {
         MctsManager::new(
             state,
             GooseMcts,
@@ -63,12 +63,12 @@ impl Search {
         )
     }
 
-    pub fn new(state: State, prev_table: PreviousTable) -> Self {
+    pub fn new(state: State, prev_table: TranspositionTable) -> Self {
         let search = Self::create_manager(state, prev_table).into();
         Self { search }
     }
 
-    pub fn table(self) -> PreviousTable {
+    pub fn table(self) -> TranspositionTable {
         let manager = self.stop_and_print_m();
         manager.table()
     }
@@ -252,7 +252,7 @@ impl Search {
                 GooseMcts,
                 policy(),
                 ApproxTable::enough_to_hold(GooseMcts.node_limit()),
-                empty_previous_table(),
+                TranspositionTable::empty(),
             );
 
             manager.playout_sync();

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,6 +1,6 @@
 use options::{set_cpuct, set_hash_size_mb, set_num_threads};
 use search::Search;
-use search_tree::{empty_previous_table, print_size_list};
+use search_tree::{print_size_list, TranspositionTable};
 use state::State;
 use std::io::{stdin, BufRead};
 use std::str::{FromStr, SplitWhitespace};
@@ -15,7 +15,7 @@ const ENGINE_AUTHOR: &str = "Princess Lana";
 const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
 pub fn main(commands: Vec<String>) {
-    let mut search = Search::new(State::default(), empty_previous_table());
+    let mut search = Search::new(State::default(), TranspositionTable::empty());
     let (sender, receiver) = channel();
     for cmd in commands {
         sender.send(cmd).unwrap();
@@ -46,7 +46,7 @@ pub fn main(commands: Vec<String>) {
                     }
                 }
                 "ucinewgame" => {
-                    search = Search::new(State::default(), empty_previous_table());
+                    search = Search::new(State::default(), TranspositionTable::empty());
                 }
                 "position"   => {
                     if let Some(state) = State::from_tokens(tokens) {


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 819 - 768 - 750  [0.511] 2337
princhess-sprt_equal-1  | ...      princhess playing White: 430 - 377 - 362  [0.523] 1169
princhess-sprt_equal-1  | ...      princhess playing Black: 389 - 391 - 388  [0.499] 1168
princhess-sprt_equal-1  | ...      White vs Black: 821 - 766 - 750  [0.512] 2337
princhess-sprt_equal-1  | Elo difference: 7.6 +/- 11.6, LOS: 90.0 %, DrawRatio: 32.1 %
princhess-sprt_equal-1  | SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```