### PR TITLE
🐛 FIX: Issue with insert in ApproxTable

### DIFF
--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -121,7 +121,7 @@ where
                         .k
                         .compare_exchange(0, my_hash, Ordering::Relaxed, Ordering::Relaxed);
                 self.size.fetch_add(1, Ordering::Relaxed);
-                match key_here {
+                return match key_here {
                     Ok(_) => get_or_write(&entry.v, value),
                     Err(v) if v == my_hash => get_or_write(&entry.v, value),
                     _ => None,


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 488 - 415 - 379  [0.528] 1282
princhess-sprt_equal-1  | ...      princhess playing White: 228 - 214 - 200  [0.511] 642
princhess-sprt_equal-1  | ...      princhess playing Black: 260 - 201 - 179  [0.546] 640
princhess-sprt_equal-1  | ...      White vs Black: 429 - 474 - 379  [0.482] 1282
princhess-sprt_equal-1  | Elo difference: 19.8 +/- 16.0, LOS: 99.2 %, DrawRatio: 29.6 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```