### PR TITLE
📦 NEW: Add Chess 960 Support

### DIFF
--- a/bin/config.yml
+++ b/bin/config.yml
@@ -26,6 +26,7 @@ challenge:
   variants:
     - standard
     - fromPosition
+    - chess960
   time_controls:
     - bullet
     - blitz

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,12 +1,14 @@
 use once_cell::sync::Lazy;
 use std::cmp::max;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::RwLock;
 
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(1);
 static HASH_SIZE_MB: AtomicUsize = AtomicUsize::new(16);
 
 static CPUCT: Lazy<RwLock<f32>> = Lazy::new(|| RwLock::new(1.79));
+
+static CHESS960: AtomicBool = AtomicBool::new(false);
 
 pub fn set_num_threads(threads: usize) {
     NUM_THREADS.store(threads, Ordering::Relaxed);
@@ -32,4 +34,12 @@ pub fn set_cpuct(c: f32) {
 pub fn get_cpuct() -> f32 {
     let cp = CPUCT.read().unwrap();
     *cp
+}
+
+pub fn set_chess960(c: bool) {
+    CHESS960.store(c, Ordering::Relaxed);
+}
+
+pub fn is_chess960() -> bool {
+    CHESS960.load(Ordering::Relaxed)
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,7 @@
 use mcts::{AsyncSearchOwned, Mcts, MctsManager, MoveInfoHandle};
-use options::{get_cpuct, get_num_threads};
+use options::{get_cpuct, get_num_threads, is_chess960};
 use search_tree::TranspositionTable;
-use shakmaty::{Color, Move};
+use shakmaty::{CastlingMode, Color, Move};
 use state::State;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::Sender;
@@ -119,7 +119,7 @@ impl Search {
                 search: manager.into(),
             };
         } else if let Some(mv) = probe_tablebase_best_move(state.board()) {
-            let uci_mv = mv.to_uci(shakmaty::CastlingMode::Standard);
+            let uci_mv = mv.to_uci(CastlingMode::from_chess960(is_chess960()));
             println!(
                 "info depth 1 seldepth 1 nodes 1 nps 1 tbhits 1 time 1 pv {}",
                 uci_mv
@@ -238,5 +238,6 @@ impl Search {
 }
 
 pub fn to_uci(mov: Move) -> String {
-    mov.to_uci(shakmaty::CastlingMode::Standard).to_string()
+    mov.to_uci(CastlingMode::from_chess960(is_chess960()))
+        .to_string()
 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,4 +1,4 @@
-use options::{set_cpuct, set_hash_size_mb, set_num_threads};
+use options::{set_chess960, set_cpuct, set_hash_size_mb, set_num_threads};
 use search::Search;
 use search_tree::{print_size_list, TranspositionTable};
 use state::State;
@@ -77,6 +77,7 @@ pub fn uci() {
     println!("option name Threads type spin min 1 max 255 default 1");
     println!("option name SyzygyPath type string");
     println!("option name CPuct type string default 1.79");
+    println!("option name UCI_Chess960 type check default false");
 
     println!("uciok");
 }
@@ -135,6 +136,7 @@ impl UciOption {
             "threads" => self.set_option(set_num_threads),
             "hash" => self.set_option(set_hash_size_mb),
             "cpuct" => self.set_option(set_cpuct),
+            "uci_chess960" => self.set_option(set_chess960),
             _ => warn!("Badly formatted or unknown option"),
         }
     }


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 840 - 788 - 726  [0.511] 2354
princhess-sprt_equal-1  | ...      princhess playing White: 443 - 374 - 361  [0.529] 1178
princhess-sprt_equal-1  | ...      princhess playing Black: 397 - 414 - 365  [0.493] 1176
princhess-sprt_equal-1  | ...      White vs Black: 857 - 771 - 726  [0.518] 2354
princhess-sprt_equal-1  | Elo difference: 7.7 +/- 11.7, LOS: 90.1 %, DrawRatio: 30.8 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```