### PR TITLE
👌 IMP: Move TranspotitionTable to transposition_table.rs

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -70,7 +70,7 @@ where
         state: State,
         manager: Spec,
         tree_policy: Spec::TreePolicy,
-        table: ApproxTable,
+        table: TranspositionTable,
         prev_table: TranspositionTable,
     ) -> Self {
         let search_tree = SearchTree::new(state, manager, tree_policy, table, prev_table);

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,6 +1,5 @@
 use mcts::{AsyncSearchOwned, Mcts, MctsManager, MoveInfoHandle};
 use options::{get_cpuct, get_num_threads, is_chess960};
-use search_tree::TranspositionTable;
 use shakmaty::{CastlingMode, Color, Move};
 use state::State;
 use std::sync::atomic::Ordering;
@@ -8,7 +7,7 @@ use std::sync::mpsc::Sender;
 use std::thread;
 use std::time::Duration;
 use tablebase::probe_tablebase_best_move;
-use transposition_table::ApproxTable;
+use transposition_table::TranspositionTable;
 use tree_policy::AlphaGoPolicy;
 use uci::Tokens;
 
@@ -59,7 +58,7 @@ impl Search {
             state,
             GooseMcts,
             policy(),
-            ApproxTable::enough_to_hold(GooseMcts.node_limit()),
+            TranspositionTable::empty(),
             prev_table,
         )
     }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,12 +1,13 @@
 use options::{set_chess960, set_cpuct, set_hash_size_mb, set_num_threads};
 use search::Search;
-use search_tree::{print_size_list, TranspositionTable};
+use search_tree::print_size_list;
 use state::State;
 use std::io::{stdin, BufRead};
 use std::str::{FromStr, SplitWhitespace};
 use std::sync::mpsc::{channel, SendError};
 use std::thread;
 use tablebase::set_tablebase_directory;
+use transposition_table::TranspositionTable;
 
 pub type Tokens<'a> = SplitWhitespace<'a>;
 


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 2239 - 2254 - 1782  [0.499] 6275
princhess-sprt_equal-1  | ...      princhess playing White: 1113 - 1129 - 895  [0.497] 3137
princhess-sprt_equal-1  | ...      princhess playing Black: 1126 - 1125 - 887  [0.500] 3138
princhess-sprt_equal-1  | ...      White vs Black: 2238 - 2255 - 1782  [0.499] 6275
princhess-sprt_equal-1  | Elo difference: -0.8 +/- 7.3, LOS: 41.1 %, DrawRatio: 28.4 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```