### PR TITLE
👌 IMP: Remove TreePolicy trait and rng

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -8,7 +8,7 @@ use std::thread;
 use std::time::Duration;
 use tablebase::probe_tablebase_best_move;
 use transposition_table::TranspositionTable;
-use tree_policy::AlphaGoPolicy;
+use tree_policy::Puct;
 use uci::Tokens;
 
 const DEFAULT_MOVE_TIME_SECS: u64 = 10;
@@ -18,17 +18,15 @@ const MOVE_OVERHEAD: Duration = Duration::from_millis(50);
 
 pub const SCALE: f32 = 1e9;
 
-fn policy() -> AlphaGoPolicy {
+fn policy() -> Puct {
     let cpuct = get_cpuct();
 
-    AlphaGoPolicy::new(cpuct * SCALE)
+    Puct::new(cpuct * SCALE)
 }
 
 pub struct GooseMcts;
 
 impl Mcts for GooseMcts {
-    type TreePolicy = AlphaGoPolicy;
-
     fn virtual_loss(&self) -> i64 {
         SCALE as i64
     }


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 716 - 658 - 623  [0.515] 1997
princhess-sprt_equal-1  | ...      princhess playing White: 352 - 340 - 307  [0.506] 999
princhess-sprt_equal-1  | ...      princhess playing Black: 364 - 318 - 316  [0.523] 998
princhess-sprt_equal-1  | ...      White vs Black: 670 - 704 - 623  [0.491] 1997
princhess-sprt_equal-1  | Elo difference: 10.1 +/- 12.6, LOS: 94.1 %, DrawRatio: 31.2 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```