### PR TITLE
📦 NEW: Upgrade arc swap to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "argparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "princhess"
 path = "src/main.rs"
 
 [dependencies]
-arc-swap = "=1.3.0"
+arc-swap = "=1.6.0"
 arrayvec = "=0.7.2"
 argparse = "=0.2.2"
 crossbeam = "=0.3.2"


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 611 - 558 - 687  [0.514] 1856
princhess-sprt_equal-1  | ...      princhess playing White: 292 - 293 - 343  [0.499] 928
princhess-sprt_equal-1  | ...      princhess playing Black: 319 - 265 - 344  [0.529] 928
princhess-sprt_equal-1  | ...      White vs Black: 557 - 612 - 687  [0.485] 1856
princhess-sprt_equal-1  | Elo difference: 9.9 +/- 12.5, LOS: 93.9 %, DrawRatio: 37.0 %
princhess-sprt_equal-1  | SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
```