### PR TITLE
👌 IMP: Fix clippy suggestion

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -72,8 +72,8 @@ fn evaluate_state(features: &[f32; state::NUMBER_FEATURES]) -> f32 {
 
     for (i, f) in features.iter().enumerate() {
         if *f > 0.5 {
-            for j in 0..hidden_layer.len() {
-                hidden_layer[j] += EVAL_HIDDEN_WEIGHTS[i][j];
+            for (j, l) in hidden_layer.iter_mut().enumerate() {
+                *l += EVAL_HIDDEN_WEIGHTS[i][j];
             }
         }
     }


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 579 - 527 - 691  [0.514] 1797
princhess-sprt_equal-1  | ...      princhess playing White: 285 - 256 - 357  [0.516] 898
princhess-sprt_equal-1  | ...      princhess playing Black: 294 - 271 - 334  [0.513] 899
princhess-sprt_equal-1  | ...      White vs Black: 556 - 550 - 691  [0.502] 1797
princhess-sprt_equal-1  | Elo difference: 10.1 +/- 12.6, LOS: 94.1 %, DrawRatio: 38.5 %
princhess-sprt_equal-1  | SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```