### PR TITLE
📦 NEW: Introduce Terminal state eval

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -8,10 +8,8 @@ use crate::search::SCALE;
 use crate::state::{self, State};
 use crate::tablebase::probe_tablebase_wdl;
 
-const MATE_FACTOR: f32 = 1.1;
-
-const MATE: StateEvaluation = StateEvaluation::Scaled((SCALE * MATE_FACTOR) as i64);
-const DRAW: StateEvaluation = StateEvaluation::Scaled(0);
+const MATE: StateEvaluation = StateEvaluation::Terminal(SCALE as i64);
+const DRAW: StateEvaluation = StateEvaluation::Terminal(0);
 
 const TB_WIN: StateEvaluation = StateEvaluation::Tablebase(SCALE as i64);
 const TB_LOSS: StateEvaluation = StateEvaluation::Tablebase(-SCALE as i64);
@@ -21,6 +19,7 @@ const TB_DRAW: StateEvaluation = StateEvaluation::Tablebase(0);
 pub enum StateEvaluation {
     Scaled(i64),
     Tablebase(i64),
+    Terminal(i64),
 }
 
 impl StateEvaluation {
@@ -32,7 +31,12 @@ impl StateEvaluation {
         match self {
             StateEvaluation::Scaled(s) => StateEvaluation::Scaled(-s),
             StateEvaluation::Tablebase(s) => StateEvaluation::Tablebase(-s),
+            StateEvaluation::Terminal(s) => StateEvaluation::Terminal(-s),
         }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, StateEvaluation::Terminal(_))
     }
 
     pub fn is_tablebase(&self) -> bool {
@@ -51,6 +55,7 @@ impl From<StateEvaluation> for i64 {
         match e {
             StateEvaluation::Scaled(s) => s,
             StateEvaluation::Tablebase(s) => s,
+            StateEvaluation::Terminal(s) => s,
         }
     }
 }

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -114,6 +114,10 @@ impl SearchNode {
         self.evaln = evaln;
     }
 
+    pub fn is_terminal(&self) -> bool {
+        self.evaln.is_terminal()
+    }
+
     pub fn is_tablebase(&self) -> bool {
         self.evaln.is_tablebase()
     }
@@ -282,6 +286,9 @@ impl SearchTree {
         loop {
             {
                 let _lock = self.ttable.flip_lock().lock().unwrap();
+            }
+            if node.is_terminal() {
+                break;
             }
             if node.hots().is_empty() || state.drawn_by_fifty_move_rule() {
                 break;


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 767 - 725 - 902  [0.509] 2394
princhess-sprt_equal-1  | ...      princhess playing White: 387 - 372 - 438  [0.506] 1197
princhess-sprt_equal-1  | ...      princhess playing Black: 380 - 353 - 464  [0.511] 1197
princhess-sprt_equal-1  | ...      White vs Black: 740 - 752 - 902  [0.497] 2394
princhess-sprt_equal-1  | Elo difference: 6.1 +/- 11.0, LOS: 86.2 %, DrawRatio: 37.7 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```