### PR TITLE
📦 NEW: Only track visits and eval on moveinfo

### DIFF
--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -70,7 +70,6 @@ impl TranspositionTable {
 
     pub fn lookup_into(&self, state: &State, dest: &mut SearchNode) {
         if let Some(src) = self.lookup(state) {
-            dest.replace(src);
             dest.set_evaln(*src.evaln());
 
             let lhs = dest.hots();


### PR DESCRIPTION
```
princhess-sprt_gain-1  | Score of princhess vs princhess-main: 363 - 278 - 433  [0.540] 1074
princhess-sprt_gain-1  | ...      princhess playing White: 187 - 145 - 206  [0.539] 538
princhess-sprt_gain-1  | ...      princhess playing Black: 176 - 133 - 227  [0.540] 536
princhess-sprt_gain-1  | ...      White vs Black: 320 - 321 - 433  [0.500] 1074
princhess-sprt_gain-1  | Elo difference: 27.6 +/- 16.1, LOS: 100.0 %, DrawRatio: 40.3 %
princhess-sprt_gain-1  | SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```