### PR TITLE
👌 IMP: Remove NodeStats trait

### DIFF
--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::arena::{Arena, ArenaAllocator, ArenaError};
 use crate::options::get_hash_size_mb;
-use crate::search_tree::{HotMoveInfo, NodeStats, SearchNode};
+use crate::search_tree::{HotMoveInfo, SearchNode};
 use crate::state::State;
 
 pub trait TranspositionHash {


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 749 - 712 - 995  [0.508] 2456
princhess-sprt_equal-1  | ...      princhess playing White: 375 - 354 - 499  [0.509] 1228
princhess-sprt_equal-1  | ...      princhess playing Black: 374 - 358 - 496  [0.507] 1228
princhess-sprt_equal-1  | ...      White vs Black: 733 - 728 - 995  [0.501] 2456
princhess-sprt_equal-1  | Elo difference: 5.2 +/- 10.6, LOS: 83.3 %, DrawRatio: 40.5 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```