### PR TITLE
👌 IMP: Remove need for node path in playouts

### DIFF
--- a/src/tree_policy.rs
+++ b/src/tree_policy.rs
@@ -1,6 +1,6 @@
 use std::f32;
 
-use crate::search_tree::{MoveInfoHandle, Moves, SearchHandle};
+use crate::search_tree::{MoveInfoHandle, Moves};
 
 #[derive(Clone, Debug)]
 pub struct Puct {
@@ -12,14 +12,12 @@ impl Puct {
         Self { cpuct }
     }
 
-    pub fn choose_child<'a>(&self, moves: Moves<'a>, handle: SearchHandle) -> MoveInfoHandle<'a> {
+    pub fn choose_child<'a>(&self, moves: Moves<'a>, is_root: bool) -> MoveInfoHandle<'a> {
         let total_visits = moves.map(|x| x.visits()).sum::<u64>() + 1;
         let sqrt_total_visits = (total_visits as f32).sqrt();
         let exploration_constant = self.cpuct;
 
         let explore_coef = exploration_constant * sqrt_total_visits;
-
-        let is_root = handle.is_root();
 
         let mut best_score = (f32::NEG_INFINITY, 1.);
         let mut choice = None;


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 768 - 730 - 992  [0.508] 2490
princhess-sprt_equal-1  | ...      princhess playing White: 393 - 363 - 489  [0.512] 1245
princhess-sprt_equal-1  | ...      princhess playing Black: 375 - 367 - 503  [0.503] 1245
princhess-sprt_equal-1  | ...      White vs Black: 760 - 738 - 992  [0.504] 2490
princhess-sprt_equal-1  | Elo difference: 5.3 +/- 10.6, LOS: 83.7 %, DrawRatio: 39.8 %
princhess-sprt_equal-1  | SPRT: llr 2.97 (100.9%), lbound -2.94, ubound 2.94 - H1 was accepted
```