### PR TITLE
👌 IMP: Make function private that did not need public

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -214,7 +214,7 @@ impl State {
         self.repetitions >= 2
     }
 
-    pub fn feature_flip(&self) -> (bool, bool) {
+    fn feature_flip(&self) -> (bool, bool) {
         let stm = self.side_to_move();
         let b = self.board.board();
 


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 1325 - 1322 - 1760  [0.500] 4407
princhess-sprt_equal-1  | ...      princhess playing White: 654 - 650 - 899  [0.501] 2203
princhess-sprt_equal-1  | ...      princhess playing Black: 671 - 672 - 861  [0.500] 2204
princhess-sprt_equal-1  | ...      White vs Black: 1326 - 1321 - 1760  [0.501] 4407
princhess-sprt_equal-1  | Elo difference: 0.2 +/- 7.9, LOS: 52.3 %, DrawRatio: 39.9 %
princhess-sprt_equal-1  | SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```