### PR TITLE
👌 IMP: Use shakmaty move methods for prev_capture

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,8 @@ use shakmaty::fen::Fen;
 use shakmaty::uci::Uci;
 use shakmaty::zobrist::{ZobristHash, ZobristValue};
 use shakmaty::{
-    self, CastlingMode, CastlingSide, Chess, Color, File, Move, MoveList, Piece, Position, Setup,
+    self, CastlingMode, CastlingSide, Chess, Color, File, Move, MoveList, Piece, Position, Role,
+    Setup,
 };
 
 use crate::options::is_chess960;
@@ -115,12 +116,10 @@ impl State {
     }
 
     pub fn make_move(&mut self, mov: &Move) {
-        let b = self.board.board();
-
-        self.prev_capture = b.role_at(mov.to());
+        self.prev_capture = mov.capture();
         self.prev_capture_sq = self.prev_capture_sq.map(|_| mov.to());
 
-        let is_pawn_move = b.pawns().contains(mov.from().unwrap());
+        let is_pawn_move = mov.role() == Role::Pawn;
 
         if is_pawn_move || self.prev_capture.is_some() {
             self.prev_state_hashes.clear();


### PR DESCRIPTION
```
sprt_equal_1    | Score of princhess vs princhess-main: 2562 - 2647 - 3892  [0.495] 9101
sprt_equal_1    | ...      princhess playing White: 1293 - 1308 - 1950  [0.498] 4551
sprt_equal_1    | ...      princhess playing Black: 1269 - 1339 - 1942  [0.492] 4550
sprt_equal_1    | ...      White vs Black: 2632 - 2577 - 3892  [0.503] 9101
sprt_equal_1    | Elo difference: -3.2 +/- 5.4, LOS: 11.9 %, DrawRatio: 42.8 %
sprt_equal_1    | SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
```