### PR TITLE
📦 NEW: Report draw on single repetition

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -335,7 +335,7 @@ impl SearchTree {
         choice: &HotMoveInfo,
         tld: &mut ThreadData<'a>,
     ) -> Result<&'a SearchNode, ArenaError> {
-        if state.drawn_by_repetition()
+        if state.is_repetition()
             || state.drawn_by_fifty_move_rule()
             || state.board().is_insufficient_material()
         {

--- a/src/state.rs
+++ b/src/state.rs
@@ -208,8 +208,8 @@ impl State {
         self.prev_state_hashes.len() > 100
     }
 
-    pub fn drawn_by_repetition(&self) -> bool {
-        self.repetitions >= 2
+    pub fn is_repetition(&self) -> bool {
+        self.repetitions > 0
     }
 
     fn feature_flip(&self) -> (bool, bool) {


### PR DESCRIPTION
```
sprt_gain_1     | Score of princhess vs princhess-main: 496 - 417 - 792  [0.523] 1705
sprt_gain_1     | ...      princhess playing White: 250 - 215 - 387  [0.521] 852
sprt_gain_1     | ...      princhess playing Black: 246 - 202 - 405  [0.526] 853
sprt_gain_1     | ...      White vs Black: 452 - 461 - 792  [0.497] 1705
sprt_gain_1     | Elo difference: 16.1 +/- 12.1, LOS: 99.6 %, DrawRatio: 46.5 %
sprt_gain_1     | SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```