### PR TITLE
👌 IMP: Count nodes in a more useful way

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -132,7 +132,7 @@ impl MctsManager {
             .as_millis();
 
         let nodes = self.tree().num_nodes();
-        let depth = fastapprox::faster::ln(nodes as f32).round();
+        let depth = (nodes as f32).log10().round();
         let pv = self.principal_variation(64);
         let sel_depth = pv.len();
         let pv_string: String = pv.into_iter().map(|x| format!(" {}", to_uci(x))).collect();

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -270,7 +270,6 @@ impl SearchTree {
 
     #[inline(never)]
     pub fn playout<'a: 'b, 'b>(&'a self, tld: &'b mut ThreadData<'a>) -> bool {
-        self.num_nodes.fetch_add(1, Ordering::Relaxed);
         let mut state = self.root_state.clone();
         let mut path: ArrayVec<MoveInfoHandle, MAX_PLAYOUT_LENGTH> = ArrayVec::new();
         let mut node = &self.root_node;
@@ -323,6 +322,9 @@ impl SearchTree {
         } else {
             node.evaln
         };
+
+        // -1 because we don't count the root node
+        self.num_nodes.fetch_add(path.len() - 1, Ordering::Relaxed);
 
         self.finish_playout(&path, evaln);
 
@@ -384,7 +386,6 @@ impl SearchTree {
             choice.child.store(existing_ptr, Ordering::Relaxed);
             return Ok(existing);
         }
-        self.num_nodes.fetch_add(1, Ordering::Relaxed);
         Ok(created)
     }
 


### PR DESCRIPTION
```
sprt_equal_1    | Score of princhess vs princhess-main: 531 - 490 - 856  [0.511] 1877
sprt_equal_1    | ...      princhess playing White: 266 - 230 - 442  [0.519] 938
sprt_equal_1    | ...      princhess playing Black: 265 - 260 - 414  [0.503] 939
sprt_equal_1    | ...      White vs Black: 526 - 495 - 856  [0.508] 1877
sprt_equal_1    | Elo difference: 7.6 +/- 11.6, LOS: 90.0 %, DrawRatio: 45.6 %
sprt_equal_1    | SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
```