### PR TITLE
📦 NEW: Depth in info is average playout depth

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -132,7 +132,7 @@ impl MctsManager {
             .as_millis();
 
         let nodes = self.tree().num_nodes();
-        let depth = (nodes as f32).log10().round();
+        let depth = nodes / self.tree().playouts();
         let pv = self.principal_variation(64);
         let sel_depth = pv.len();
         let pv_string: String = pv.into_iter().map(|x| format!(" {}", to_uci(x))).collect();

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -31,6 +31,7 @@ pub struct SearchTree {
     ttable: LRTable,
 
     num_nodes: AtomicUsize,
+    playouts: AtomicUsize,
     tb_hits: AtomicUsize,
 }
 
@@ -244,6 +245,7 @@ impl SearchTree {
             root_table,
             ttable: LRTable::new(current_table, previous_table),
             num_nodes: 1.into(),
+            playouts: 0.into(),
             tb_hits,
         }
     }
@@ -258,6 +260,10 @@ impl SearchTree {
 
     pub fn num_nodes(&self) -> usize {
         self.num_nodes.load(Ordering::Relaxed)
+    }
+
+    pub fn playouts(&self) -> usize {
+        self.playouts.load(Ordering::Relaxed)
     }
 
     pub fn tb_hits(&self) -> usize {
@@ -325,6 +331,7 @@ impl SearchTree {
 
         // -1 because we don't count the root node
         self.num_nodes.fetch_add(path.len() - 1, Ordering::Relaxed);
+        self.playouts.fetch_add(1, Ordering::Relaxed);
 
         self.finish_playout(&path, evaln);
 


### PR DESCRIPTION
```
sprt_equal_1    | Score of princhess vs princhess-main: 1815 - 1857 - 2910  [0.497] 6582
sprt_equal_1    | ...      princhess playing White: 885 - 943 - 1464  [0.491] 3292
sprt_equal_1    | ...      princhess playing Black: 930 - 914 - 1446  [0.502] 3290
sprt_equal_1    | ...      White vs Black: 1799 - 1873 - 2910  [0.494] 6582
sprt_equal_1    | Elo difference: -2.2 +/- 6.3, LOS: 24.4 %, DrawRatio: 44.2 %
sprt_equal_1    | SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```