### PR TITLE
📦 NEW: Have seldepth report the max playout depth

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -133,8 +133,8 @@ impl MctsManager {
 
         let nodes = self.tree().num_nodes();
         let depth = nodes / self.tree().playouts();
+        let sel_depth = self.tree().max_depth();
         let pv = self.principal_variation(64);
-        let sel_depth = pv.len();
         let pv_string: String = pv.into_iter().map(|x| format!(" {}", to_uci(x))).collect();
 
         let nps = nodes * 1000 / search_time_ms as usize;


### PR DESCRIPTION
```
sprt_equal_1    | Score of princhess vs princhess-main: 1036 - 1036 - 1918  [0.500] 3990                                         
│sprt_equal_1    | ...      princhess playing White: 537 - 497 - 961  [0.510] 1995                                 
│sprt_equal_1    | ...      princhess playing Black: 499 - 539 - 957  [0.490] 1995                                                                                                   
│sprt_equal_1    | ...      White vs Black: 1076 - 996 - 1918  [0.510] 3990                              
│sprt_equal_1    | Elo difference: 0.0 +/- 7.8, LOS: 50.0 %, DrawRatio: 48.1 %                        
│sprt_equal_1    | SPRT: llr 2.98 (101.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```