### PR TITLE
🐛 FIX: Ensure visited value is used with nodes from table

### DIFF
--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -67,6 +67,7 @@ impl TranspositionTable {
     pub fn lookup_into(&self, state: &State, dest: &mut SearchNode) {
         if let Some(src) = self.lookup(state) {
             dest.set_evaln(*src.evaln());
+            dest.visited();
 
             let lhs = dest.hots();
             let rhs = src.hots();


### PR DESCRIPTION
```
princhess-sprt_gain-1  | Score of princhess vs princhess-main: 688 - 597 - 828  [0.522] 2113
princhess-sprt_gain-1  | ...      princhess playing White: 513 - 137 - 407  [0.678] 1057
princhess-sprt_gain-1  | ...      princhess playing Black: 175 - 460 - 421  [0.365] 1056
princhess-sprt_gain-1  | ...      White vs Black: 973 - 312 - 828  [0.656] 2113
princhess-sprt_gain-1  | Elo difference: 15.0 +/- 11.5, LOS: 99.4 %, DrawRatio: 39.2 %
princhess-sprt_gain-1  | SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```