### PR TITLE
👌 IMP: Remove unneded memory copy

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -134,8 +134,6 @@ fn run_nets(state: &State, moves: &MoveList) -> (f32, Vec<f32>) {
         mem::transmute(out)
     };
 
-    hidden_layer.copy_from_slice(&EVAL_HIDDEN_BIAS);
-
     state.features_map(|idx| {
         for (j, l) in hidden_layer.iter_mut().enumerate() {
             *l += EVAL_HIDDEN_WEIGHTS[idx][j]


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 887 - 855 - 1111  [0.506] 2853
princhess-sprt_equal-1  | ...      princhess playing White: 716 - 188 - 523  [0.685] 1427
princhess-sprt_equal-1  | ...      princhess playing Black: 171 - 667 - 588  [0.326] 1426
princhess-sprt_equal-1  | ...      White vs Black: 1383 - 359 - 1111  [0.679] 2853
princhess-sprt_equal-1  | Elo difference: 3.9 +/- 10.0, LOS: 77.8 %, DrawRatio: 38.9 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```