### PR TITLE
👌 IMP: Return a non-empty tt if there is one

### DIFF
--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -32,6 +32,10 @@ impl TranspositionTable {
         Self { table, arena }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
     pub fn arena(&self) -> &Arena {
         &self.arena
     }
@@ -141,7 +145,9 @@ impl LRTable {
     }
 
     pub fn table(self) -> TranspositionTable {
-        if self.is_left_current() {
+        if self.left.is_empty() {
+            self.right
+        } else if self.right.is_empty() || self.is_left_current() {
             self.left
         } else {
             self.right


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 1879 - 1872 - 1408  [0.501] 5159
princhess-sprt_equal-1  | ...      princhess playing White: 1343 - 540 - 696  [0.656] 2579
princhess-sprt_equal-1  | ...      princhess playing Black: 536 - 1332 - 712  [0.346] 2580
princhess-sprt_equal-1  | ...      White vs Black: 2675 - 1076 - 1408  [0.655] 5159
princhess-sprt_equal-1  | Elo difference: 0.5 +/- 8.1, LOS: 54.5 %, DrawRatio: 27.3 %
princhess-sprt_equal-1  | SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
```