### PR TITLE
🐛 FIX: Fix crashes on info output sometimes

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -347,7 +347,7 @@ impl SearchTree {
         self.max_depth.fetch_max(depth, Ordering::Relaxed);
         let playouts = self.playouts.fetch_add(1, Ordering::Relaxed);
 
-        if playouts > 1024 && (playouts & (playouts - 1)) == 0 {
+        if playouts > 4096 && (playouts & (playouts - 1)) == 0 {
             self.print_info(&time_management);
         }
 
@@ -455,6 +455,10 @@ impl SearchTree {
 
     fn print_info(&self, time_management: &TimeManagement) {
         let search_time_ms = time_management.elapsed().as_millis();
+
+        if search_time_ms == 0 {
+            return;
+        }
 
         let nodes = self.num_nodes();
         let depth = nodes / self.playouts();


### PR DESCRIPTION
```
princhess-elo_check-1  | Player: princhess
princhess-elo_check-1  |    "Draw by 3-fold repetition": 29
princhess-elo_check-1  |    "Loss: Black mates": 8
princhess-elo_check-1  |    "Loss: White mates": 23
princhess-elo_check-1  |    "Win: Black disconnects": 2
princhess-elo_check-1  |    "Win: Black mates": 7
princhess-elo_check-1  |    "Win: White disconnects": 4
princhess-elo_check-1  |    "Win: White mates": 27
princhess-elo_check-1  | Player: princhess-main
princhess-elo_check-1  |    "Draw by 3-fold repetition": 29
princhess-elo_check-1  |    "Loss: Black disconnects": 2
princhess-elo_check-1  |    "Loss: Black mates": 7
princhess-elo_check-1  |    "Loss: White disconnects": 4
princhess-elo_check-1  |    "Loss: White mates": 27
princhess-elo_check-1  |    "Win: Black mates": 8
princhess-elo_check-1  |    "Win: White mates": 23
```