### PR TITLE
📦 NEW: Reduce scale

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -14,7 +14,7 @@ const DEFAULT_MOVE_TIME_FRACTION: u32 = 20;
 
 const MOVE_OVERHEAD: Duration = Duration::from_millis(50);
 
-pub const SCALE: f32 = 1e9;
+pub const SCALE: f32 = 255. * 255.;
 
 #[derive(Copy, Clone, Debug)]
 pub struct TimeManagement {


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 1828 - 1729 - 1757  [0.509] 5314
princhess-sprt_equal-1  | ...      princhess playing White: 944 - 838 - 875  [0.520] 2657
princhess-sprt_equal-1  | ...      princhess playing Black: 884 - 891 - 882  [0.499] 2657
princhess-sprt_equal-1  | ...      White vs Black: 1835 - 1722 - 1757  [0.511] 5314
princhess-sprt_equal-1  | Elo difference: 6.5 +/- 7.6, LOS: 95.2 %, DrawRatio: 33.1 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```