### PR TITLE
👌 IMP: Just use floats for selecting best child

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -493,14 +493,18 @@ impl SearchTree {
 }
 
 fn select_child_after_search<'a>(children: &[MoveInfoHandle<'a>]) -> MoveInfoHandle<'a> {
-    *children
-        .iter()
-        .max_by_key(|child| {
-            child
-                .average_reward()
-                .map_or(-SCALE as i64, |r| r.round() as i64)
-        })
-        .unwrap()
+    let mut best = children[0];
+    let mut best_reward = best.average_reward().unwrap_or(-SCALE);
+
+    for child in children.iter().skip(1) {
+        let reward = child.average_reward().unwrap_or(-SCALE);
+        if reward > best_reward {
+            best = *child;
+            best_reward = reward;
+        }
+    }
+
+    best
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 1711 - 1607 - 1563  [0.511] 4881
princhess-sprt_equal-1  | ...      princhess playing White: 869 - 821 - 751  [0.510] 2441
princhess-sprt_equal-1  | ...      princhess playing Black: 842 - 786 - 812  [0.511] 2440
princhess-sprt_equal-1  | ...      White vs Black: 1655 - 1663 - 1563  [0.499] 4881
princhess-sprt_equal-1  | Elo difference: 7.4 +/- 8.0, LOS: 96.5 %, DrawRatio: 32.0 %
princhess-sprt_equal-1  | SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```