### PR TITLE
📦 NEW: Use negative parent Q as fpu

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -282,7 +282,12 @@ impl SearchTree {
             if path.len() >= MAX_PLAYOUT_LENGTH {
                 break;
             }
-            let choice = tree_policy::choose_child(node.hots(), self.cpuct, path.is_empty());
+
+            let fpu = path
+                .last()
+                .map_or(0, |x| -x.sum_rewards() / i64::from(x.visits()));
+
+            let choice = tree_policy::choose_child(node.hots(), self.cpuct, fpu, path.is_empty());
             choice.down();
             path.push(choice);
             state.make_move(&choice.mov);

--- a/src/tree_policy.rs
+++ b/src/tree_policy.rs
@@ -4,7 +4,7 @@ use std::f32;
 use crate::search::SCALE;
 use crate::search_tree::HotMoveInfo;
 
-pub fn choose_child(moves: &[HotMoveInfo], cpuct: f32, is_root: bool) -> &HotMoveInfo {
+pub fn choose_child(moves: &[HotMoveInfo], cpuct: f32, fpu: i64, is_root: bool) -> &HotMoveInfo {
     let total_visits = moves.iter().map(|v| u64::from(v.visits())).sum::<u64>() + 1;
     let sqrt_total_visits = (total_visits as f32).sqrt();
 
@@ -30,7 +30,7 @@ pub fn choose_child(moves: &[HotMoveInfo], cpuct: f32, is_root: bool) -> &HotMov
         let q = if child_visits > 0 {
             sum_rewards / child_visits
         } else {
-            0
+            fpu
         };
 
         let u = explore_coef * i64::from(policy_evaln) / ((child_visits + 1) * SCALE as i64);


### PR DESCRIPTION
```
 Score of princhess vs princhess-main: 1032 - 892 - 1406  [0.521] 3330
 ...      princhess playing White: 510 - 462 - 693  [0.514] 1665
 ...      princhess playing Black: 522 - 430 - 713  [0.528] 1665
 ...      White vs Black: 940 - 984 - 1406  [0.493] 3330
 Elo difference: 14.6 +/- 9.0, LOS: 99.9 %, DrawRatio: 42.2 %
 SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```