### PR TITLE
👌 IMP: Include score in tb move info

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       dockerfile: bin/Dockerfile.cutechess-cli
     command:
       -engine cmd=/engines/princhess name=princhess
-      -engine cmd=/engines/princhess-main name=princhess
+      -engine cmd=/engines/princhess-main name=princhess-main
 
       -each proto=uci tc=8+0.08
             option.SyzygyPath=/syzygy option.Hash=128 option.Threads=1

--- a/src/search.rs
+++ b/src/search.rs
@@ -130,9 +130,17 @@ impl Search {
             return Self {
                 search: manager.into(),
             };
-        } else if let Some(mv) = tablebase::probe_best_move(state.board()) {
+        } else if let Some((mv, wdl)) = tablebase::probe_best_move(state.board()) {
             let uci_mv = to_uci(&mv);
-            println!("info depth 1 seldepth 1 nodes 1 nps 1 tbhits 1 time 1 pv {uci_mv}");
+
+            let score = match wdl {
+                tablebase::Wdl::Win => 1000,
+                tablebase::Wdl::Loss => -1000,
+                tablebase::Wdl::Draw => 0,
+            };
+            println!(
+                "info depth 1 seldepth 1 nodes 1 nps 1 tbhits 1 score cp {score} time 1 pv {uci_mv}"
+            );
             println!("bestmove {uci_mv}");
             return Self {
                 search: manager.into(),

--- a/src/tablebase/mod.rs
+++ b/src/tablebase/mod.rs
@@ -72,7 +72,7 @@ pub fn probe_wdl(pos: &Chess) -> Option<Wdl> {
     }
 }
 
-pub fn probe_best_move(pos: &Chess) -> Option<Move> {
+pub fn probe_best_move(pos: &Chess) -> Option<(Move, Wdl)> {
     let b = pos.board();
 
     if b.occupied().count() > max_pieces() {
@@ -104,6 +104,12 @@ pub fn probe_best_move(pos: &Chess) -> Option<Move> {
             return None;
         }
 
+        let wdl = match (root & bindings::TB_RESULT_WDL_MASK) >> bindings::TB_RESULT_WDL_SHIFT {
+            bindings::TB_WIN => Wdl::Win,
+            bindings::TB_LOSS => Wdl::Loss,
+            _ => Wdl::Draw,
+        };
+
         let from =
             Square::new((root & bindings::TB_RESULT_FROM_MASK) >> bindings::TB_RESULT_FROM_SHIFT);
         let to = Square::new((root & bindings::TB_RESULT_TO_MASK) >> bindings::TB_RESULT_TO_SHIFT);
@@ -120,7 +126,7 @@ pub fn probe_best_move(pos: &Chess) -> Option<Move> {
 
         for m in pos.legal_moves() {
             if m.from() == Some(from) && m.to() == to && m.promotion() == promotion_role {
-                return Some(m);
+                return Some((m, wdl));
             }
         }
     }


### PR DESCRIPTION
Visual change only.

Sanity check on elo:
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 65 - 66 - 69  [0.497] 200
princhess-sprt_equal-1  | ...      princhess playing White: 37 - 30 - 34  [0.535] 101
princhess-sprt_equal-1  | ...      princhess playing Black: 28 - 36 - 35  [0.460] 99
princhess-sprt_equal-1  | ...      White vs Black: 73 - 58 - 69  [0.537] 200
princhess-sprt_equal-1  | Elo difference: -1.7 +/- 39.1, LOS: 46.5 %, DrawRatio: 34.5 %
princhess-sprt_equal-1  | SPRT: llr 0.00988 (0.3%), lbound -2.25, ubound 2.89
```