### PR TITLE
🐛 FIX: Correct depth calculation

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -317,8 +317,7 @@ impl SearchTree {
 
         Self::finish_playout(&path, evaln);
 
-        // -1 because we don't count the root node
-        let depth = path.len() - 1;
+        let depth = path.len();
         let num_nodes = self.num_nodes.fetch_add(depth, Ordering::Relaxed) + depth;
         self.max_depth.fetch_max(depth, Ordering::Relaxed);
         let playouts = self.playouts.fetch_add(1, Ordering::Relaxed) + 1;


### PR DESCRIPTION
Sanity check against crashing/elo loss
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 31 - 32 - 37  [0.495] 100
princhess-sprt_equal-1  | ...      princhess playing White: 17 - 14 - 19  [0.530] 50
princhess-sprt_equal-1  | ...      princhess playing Black: 14 - 18 - 18  [0.460] 50
princhess-sprt_equal-1  | ...      White vs Black: 35 - 28 - 37  [0.535] 100
princhess-sprt_equal-1  | Elo difference: -3.5 +/- 54.4, LOS: 45.0 %, DrawRatio: 37.0 %
princhess-sprt_equal-1  | SPRT: llr -0.00616 (-0.2%), lbound -2.25, ubound 2.89
```