### PR TITLE
👌 IMP: Refactor SearchTree#descend

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -36,7 +36,7 @@ impl Flag {
 }
 
 pub fn evaluate_state(state: &State) -> i64 {
-    return (run_eval_net(state) * SCALE) as i64;
+    (run_eval_net(state) * SCALE) as i64
 }
 
 pub fn evaluate_state_flag(state: &State, moves: &MoveList) -> Flag {


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 324 - 294 - 382  [0.515] 1000
princhess-sprt_equal-1  | ...      princhess playing White: 176 - 142 - 182  [0.534] 500
princhess-sprt_equal-1  | ...      princhess playing Black: 148 - 152 - 200  [0.496] 500
princhess-sprt_equal-1  | ...      White vs Black: 328 - 290 - 382  [0.519] 1000
princhess-sprt_equal-1  | Elo difference: 10.4 +/- 16.9, LOS: 88.6 %, DrawRatio: 38.2 %
princhess-sprt_equal-1  | SPRT: llr 0.867 (30.0%), lbound -2.25, ubound 2.89
```

Zero crashes:
```
princhess-tune_gauntlet-1  | Rank Name                          Elo     +/-   Games   Score    Draw
princhess-tune_gauntlet-1  |    1 princhess-4                   105      46     150   64.7%   36.0%
princhess-tune_gauntlet-1  |    2 princhess-2                    33      44     150   54.7%   37.3%
princhess-tune_gauntlet-1  |    3 princhess-3                    23      43     150   53.3%   41.3%
princhess-tune_gauntlet-1  |    4 princhess-1                  -170      48     150   27.3%   33.3%
```