### PR TITLE
📦 NEW: Refactor to own square type

### DIFF
--- a/src/chess/mod.rs
+++ b/src/chess/mod.rs
@@ -1,0 +1,6 @@
+mod mv;
+mod square;
+
+pub use crate::chess::mv::Move;
+pub use crate::chess::mv::MoveList;
+pub use crate::chess::square::Square;

--- a/src/chess/mv.rs
+++ b/src/chess/mv.rs
@@ -1,3 +1,4 @@
+use crate::chess::Square;
 use crate::options::is_chess960;
 use arrayvec::ArrayVec;
 
@@ -40,14 +41,12 @@ impl Move {
         Self(Self::new(king, rook).0 | Self::CASTLE_FLAG)
     }
 
-    pub fn from(self) -> shakmaty::Square {
-        unsafe { shakmaty::Square::new_unchecked(u32::from(self.0 & Self::SQ_MASK)) }
+    pub fn from(self) -> Square {
+        Square::from(self.0 & Self::SQ_MASK)
     }
 
-    pub fn to(self) -> shakmaty::Square {
-        unsafe {
-            shakmaty::Square::new_unchecked(u32::from((self.0 >> Self::TO_SHIFT) & Self::SQ_MASK))
-        }
+    pub fn to(self) -> Square {
+        Square::from((self.0 >> Self::TO_SHIFT) & Self::SQ_MASK)
     }
 
     pub fn is_normal(self) -> bool {
@@ -80,10 +79,10 @@ impl Move {
         let from = self.from();
         let to = if self.is_castle() && !is_chess960() {
             match self.to() {
-                shakmaty::Square::H1 => shakmaty::Square::G1,
-                shakmaty::Square::A1 => shakmaty::Square::C1,
-                shakmaty::Square::H8 => shakmaty::Square::G8,
-                shakmaty::Square::A8 => shakmaty::Square::C8,
+                Square::H1 => Square::G1,
+                Square::A1 => Square::C1,
+                Square::H8 => Square::G8,
+                Square::A8 => Square::C8,
                 _ => panic!("Invalid castle move: {self:?}"),
             }
         } else {
@@ -98,8 +97,8 @@ impl Move {
     }
 
     pub fn to_shakmaty(self, board: &shakmaty::Board) -> shakmaty::Move {
-        let from = self.from();
-        let to = self.to();
+        let from = shakmaty::Square::from(self.from());
+        let to = shakmaty::Square::from(self.to());
 
         if self.is_enpassant() {
             return shakmaty::Move::EnPassant { from, to };

--- a/src/chess/square.rs
+++ b/src/chess/square.rs
@@ -1,0 +1,49 @@
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Square(u8);
+
+impl Square {
+    pub const A1: Square = Square(0);
+    pub const C1: Square = Square(2);
+    pub const G1: Square = Square(6);
+    pub const H1: Square = Square(7);
+
+    pub const A8: Square = Square(56);
+    pub const C8: Square = Square(58);
+    pub const G8: Square = Square(62);
+    pub const H8: Square = Square(63);
+}
+
+impl From<shakmaty::Square> for Square {
+    fn from(square: shakmaty::Square) -> Self {
+        Square::from(square as u8)
+    }
+}
+
+impl From<Square> for shakmaty::Square {
+    fn from(square: Square) -> Self {
+        unsafe { shakmaty::Square::new_unchecked(u32::from(square.0)) }
+    }
+}
+
+impl From<u8> for Square {
+    fn from(square: u8) -> Self {
+        Square(square)
+    }
+}
+
+impl From<u16> for Square {
+    fn from(square: u16) -> Self {
+        Square(square as u8)
+    }
+}
+
+impl Display for Square {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let file = ((self.0 & 7) + b'a') as char;
+        let rank = (self.0 / 8) + 1;
+
+        write!(f, "{file}{rank}")
+    }
+}


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 4152 - 4132 - 5608  [0.501] 13892
princhess-sprt_equal-1  | ...      princhess playing White: 2079 - 2040 - 2827  [0.503] 6946
princhess-sprt_equal-1  | ...      princhess playing Black: 2073 - 2092 - 2781  [0.499] 6946
princhess-sprt_equal-1  | ...      White vs Black: 4171 - 4113 - 5608  [0.502] 13892
princhess-sprt_equal-1  | Elo difference: 0.5 +/- 4.5, LOS: 58.7 %, DrawRatio: 40.4 %
princhess-sprt_equal-1  | SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```