### PR TITLE
👌 IMP: Refactor repetition handling

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -18,8 +18,6 @@ pub struct State {
     prev_state_hashes: ArrayVec<u64, 128>,
 
     prev_moves: [Option<Move>; 2],
-
-    repetitions: usize,
 }
 
 impl State {
@@ -28,7 +26,6 @@ impl State {
             board,
             prev_state_hashes: ArrayVec::new(),
             prev_moves: [None, None],
-            repetitions: 0,
         }
     }
 
@@ -69,7 +66,6 @@ impl State {
             board,
             prev_state_hashes: ArrayVec::new(),
             prev_moves: [None, None],
-            repetitions: 0,
         })
     }
 
@@ -105,17 +101,6 @@ impl State {
         self.prev_state_hashes.push(self.hash());
 
         self.board.play(mov);
-
-        self.check_for_repetition();
-    }
-
-    fn check_for_repetition(&mut self) {
-        let crnt_hash = self.hash();
-        self.repetitions = self
-            .prev_state_hashes
-            .iter()
-            .filter(|h| **h == crnt_hash)
-            .count();
     }
 
     pub fn halfmove_counter(&self) -> usize {
@@ -127,7 +112,14 @@ impl State {
     }
 
     pub fn is_repetition(&self) -> bool {
-        self.repetitions > 0
+        let crnt_hash = self.hash();
+
+        self.prev_state_hashes
+            .iter()
+            .rev()
+            .skip(1)
+            .step_by(2)
+            .any(|h| *h == crnt_hash)
     }
 
     fn feature_flip(&self) -> (bool, bool) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -114,12 +114,7 @@ impl State {
     pub fn is_repetition(&self) -> bool {
         let crnt_hash = self.hash();
 
-        self.prev_state_hashes
-            .iter()
-            .rev()
-            .skip(1)
-            .step_by(2)
-            .any(|h| *h == crnt_hash)
+        self.prev_state_hashes.iter().rev().any(|h| *h == crnt_hash)
     }
 
     fn feature_flip(&self) -> (bool, bool) {


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 2057 - 1985 - 2728  [0.505] 6770
princhess-sprt_equal-1  | ...      princhess playing White: 1071 - 950 - 1364  [0.518] 3385
princhess-sprt_equal-1  | ...      princhess playing Black: 986 - 1035 - 1364  [0.493] 3385
princhess-sprt_equal-1  | ...      White vs Black: 2106 - 1936 - 2728  [0.513] 6770
princhess-sprt_equal-1  | Elo difference: 3.7 +/- 6.4, LOS: 87.1 %, DrawRatio: 40.3 %
princhess-sprt_equal-1  | SPRT: llr 2.91 (100.7%), lbound -2.25, ubound 2.89 - H1 was accepted
```