### PR TITLE
👌 IMP: Use lookups for knight/king/pawn attacks

### DIFF
--- a/src/chess/attacks.rs
+++ b/src/chess/attacks.rs
@@ -1,0 +1,64 @@
+use crate::chess::{Bitboard, Color, Square};
+
+const NOT_A_FILE: u64 = 0xfefe_fefe_fefe_fefe;
+const NOT_H_FILE: u64 = 0x7f7f_7f7f_7f7f_7f7f;
+
+const fn init_pawn_attacks() -> [[Bitboard; 64]; 2] {
+    let mut attacks = [[Bitboard::EMPTY; 64]; 2];
+    let mut sq = 0;
+    while sq < 64 {
+        attacks[0][sq] =
+            Bitboard::new((((1 << sq) & NOT_A_FILE) << 7) | (((1 << sq) & NOT_H_FILE) << 9));
+        attacks[1][sq] =
+            Bitboard::new((((1 << sq) & NOT_A_FILE) >> 9) | (((1 << sq) & NOT_H_FILE) >> 7));
+
+        sq += 1;
+    }
+    attacks
+}
+
+const fn init_knight_attacks() -> [Bitboard; 64] {
+    let mut attacks = [Bitboard::EMPTY; 64];
+    let mut sq = 0;
+    while sq < 64 {
+        let n = 1 << sq;
+        let h1 = ((n >> 1) & 0x7f7f_7f7f_7f7f_7f7f) | ((n << 1) & 0xfefe_fefe_fefe_fefe);
+        let h2 = ((n >> 2) & 0x3f3f_3f3f_3f3f_3f3f) | ((n << 2) & 0xfcfc_fcfc_fcfc_fcfc);
+        let bb = (h1 << 16) | (h1 >> 16) | (h2 << 8) | (h2 >> 8);
+
+        attacks[sq] = Bitboard::new(bb);
+        sq += 1;
+    }
+    attacks
+}
+
+const fn init_king_attacks() -> [Bitboard; 64] {
+    let mut attacks = [Bitboard::EMPTY; 64];
+    let mut sq = 0;
+    while sq < 64 {
+        let mut k = 1 << sq;
+        k |= (k << 8) | (k >> 8);
+        k |= ((k & NOT_A_FILE) >> 1) | ((k & NOT_H_FILE) << 1);
+        k ^= 1 << sq;
+
+        attacks[sq] = Bitboard::new(k);
+        sq += 1;
+    }
+    attacks
+}
+
+const PAWN_ATTACKS: [[Bitboard; 64]; 2] = init_pawn_attacks();
+const KNIGHT_ATTACKS: [Bitboard; 64] = init_knight_attacks();
+const KING_ATTACKS: [Bitboard; 64] = init_king_attacks();
+
+pub fn pawn(color: Color, square: Square) -> Bitboard {
+    PAWN_ATTACKS[color.index()][square.index()]
+}
+
+pub fn knight(square: Square) -> Bitboard {
+    KNIGHT_ATTACKS[square.index()]
+}
+
+pub fn king(square: Square) -> Bitboard {
+    KING_ATTACKS[square.index()]
+}

--- a/src/chess/bitboard.rs
+++ b/src/chess/bitboard.rs
@@ -1,16 +1,40 @@
 use std::iter::FusedIterator;
+use std::ops::{BitAnd, BitOr};
 
 use crate::chess::Square;
 
+#[derive(Copy, Clone)]
 pub struct Bitboard(pub u64);
 
 impl Bitboard {
-    pub fn any(&self) -> bool {
+    pub const EMPTY: Self = Self(0);
+
+    pub const fn new(bb: u64) -> Self {
+        Self(bb)
+    }
+
+    pub fn any(self) -> bool {
         self.0 != 0
     }
 
-    pub fn count(&self) -> usize {
+    pub fn count(self) -> usize {
         self.0.count_ones() as usize
+    }
+}
+
+impl BitAnd for Bitboard {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl BitOr for Bitboard {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
     }
 }
 

--- a/src/chess/color.rs
+++ b/src/chess/color.rs
@@ -6,6 +6,18 @@ pub struct Color(bool);
 impl Color {
     pub const WHITE: Color = Color(false);
     pub const BLACK: Color = Color(true);
+
+    pub fn index(self) -> usize {
+        usize::from(self.0)
+    }
+
+    pub fn fold<T>(self, white: T, black: T) -> T {
+        if self.0 {
+            black
+        } else {
+            white
+        }
+    }
 }
 
 impl From<shakmaty::Color> for Color {

--- a/src/chess/mod.rs
+++ b/src/chess/mod.rs
@@ -1,3 +1,4 @@
+mod attacks;
 mod bitboard;
 mod board;
 mod color;

--- a/src/state.rs
+++ b/src/state.rs
@@ -161,12 +161,12 @@ impl State {
 
             if piece != Piece::KING {
                 // Threats
-                if b.attacks_to(sq, !color, b.occupied()).any() {
+                if b.is_attacked(sq, !color, b.occupied()) {
                     f(OFFSET_THREATS + feature_idx(sq, piece, color));
                 }
 
                 // Defenses
-                if b.attacks_to(sq, color, b.occupied()).any() {
+                if b.is_attacked(sq, color, b.occupied()) {
                     f(OFFSET_DEFENDS + feature_idx(sq, piece, color));
                 }
             }


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 2467 - 2407 - 3350  [0.504] 8224
princhess-sprt_equal-1  | ...      princhess playing White: 1279 - 1175 - 1659  [0.513] 4113
princhess-sprt_equal-1  | ...      princhess playing Black: 1188 - 1232 - 1691  [0.495] 4111
princhess-sprt_equal-1  | ...      White vs Black: 2511 - 2363 - 3350  [0.509] 8224
princhess-sprt_equal-1  | Elo difference: 2.5 +/- 5.8, LOS: 80.5 %, DrawRatio: 40.7 %
princhess-sprt_equal-1  | SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```