### PR TITLE
📦 NEW: Track own stm and ep squares

### DIFF
--- a/src/chess/square.rs
+++ b/src/chess/square.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Display, Formatter};
+use std::ops::Sub;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Square(u8);
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -39,6 +40,14 @@ impl Square {
     pub fn index(self) -> usize {
         self.0 as usize
     }
+
+    pub fn rank(self) -> Rank {
+        Rank(self.0 / 8)
+    }
+
+    pub fn with_rank(self, rank: Rank) -> Square {
+        Square(self.0 & 7 + rank.0 * 8)
+    }
 }
 
 impl File {
@@ -48,6 +57,17 @@ impl File {
 impl Rank {
     pub const _1: Rank = Rank(0);
     pub const _2: Rank = Rank(1);
+    pub const _3: Rank = Rank(2);
+    pub const _6: Rank = Rank(5);
+}
+
+impl Sub for Rank {
+    type Output = i8;
+
+    #[allow(clippy::cast_possible_wrap)]
+    fn sub(self, rhs: Rank) -> Self::Output {
+        self.0 as i8 - rhs.0 as i8
+    }
 }
 
 impl From<shakmaty::Square> for Square {

--- a/src/state.rs
+++ b/src/state.rs
@@ -100,7 +100,7 @@ impl State {
         }
         self.prev_state_hashes.push(self.hash());
 
-        self.board.play(mov);
+        self.board.make_move(mov);
     }
 
     pub fn halfmove_counter(&self) -> usize {


### PR DESCRIPTION
```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 1242 - 1159 - 1858  [0.510] 4259
princhess-sprt_equal-1  | ...      princhess playing White: 595 - 595 - 940  [0.500] 2130
princhess-sprt_equal-1  | ...      princhess playing Black: 647 - 564 - 918  [0.519] 2129
princhess-sprt_equal-1  | ...      White vs Black: 1159 - 1242 - 1858  [0.490] 4259
princhess-sprt_equal-1  | Elo difference: 6.8 +/- 7.8, LOS: 95.5 %, DrawRatio: 43.6 %
princhess-sprt_equal-1  | SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```