### PR TITLE
👌 IMP: Clippy fixes

### DIFF
--- a/src/chess/square.rs
+++ b/src/chess/square.rs
@@ -46,7 +46,7 @@ impl Square {
     }
 
     pub fn with_rank(self, rank: Rank) -> Square {
-        Square(self.0 & 7 + rank.0 * 8)
+        Square((self.0 & 7) + rank.0 * 8)
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -303,7 +303,7 @@ impl Search {
     }
 
     pub fn best_move(&self) -> Move {
-        *self.principal_variation(1).get(0).unwrap()
+        *self.principal_variation(1).first().unwrap()
     }
 }
 

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -481,7 +481,7 @@ impl SearchTree {
 
     pub fn eval(&self) -> f32 {
         self.principal_variation(1)
-            .get(0)
+            .first()
             .map_or(0., |x| x.average_reward().unwrap_or(-SCALE) / SCALE)
     }
 


### PR DESCRIPTION
Small refactoring. Check against catastrophic elo loss.

```
princhess-sprt_equal-1  | Score of princhess vs princhess-main: 47 - 49 - 104  [0.495] 200
princhess-sprt_equal-1  | ...      princhess playing White: 25 - 23 - 52  [0.510] 100
princhess-sprt_equal-1  | ...      princhess playing Black: 22 - 26 - 52  [0.480] 100
princhess-sprt_equal-1  | ...      White vs Black: 51 - 45 - 104  [0.515] 200
princhess-sprt_equal-1  | Elo difference: -3.5 +/- 33.4, LOS: 41.9 %, DrawRatio: 52.0 %
```