### PR TITLE
📦 NEW: Remove sudden death time management

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -194,22 +194,16 @@ impl Search {
         } else if let Some(mt) = move_time {
             think_time = TimeManagement::from_duration(mt);
         } else if let Some(r) = remaining {
-            think_time =
-                if movestogo.is_none() && increment.is_zero() && r < Duration::from_millis(60000) {
-                    TimeManagement::from_duration(r / 60)
-                } else {
-                    let move_time_fraction = match movestogo {
-                        // plus 2 because we want / 3 to be the max_think_time
-                        Some(m) => (m + 2).min(DEFAULT_MOVE_TIME_FRACTION),
-                        None => DEFAULT_MOVE_TIME_FRACTION,
-                    };
+            let move_time_fraction = match movestogo {
+                // plus 2 because we want / 3 to be the max_think_time
+                Some(m) => (m + 2).min(DEFAULT_MOVE_TIME_FRACTION),
+                None => DEFAULT_MOVE_TIME_FRACTION,
+            };
 
-                    let ideal_think_time =
-                        (r + 20 * increment - MOVE_OVERHEAD) / move_time_fraction;
-                    let max_think_time = r / 3;
+            let ideal_think_time = (r + 20 * increment - MOVE_OVERHEAD) / move_time_fraction;
+            let max_think_time = r / 3;
 
-                    TimeManagement::from_duration(ideal_think_time.min(max_think_time))
-                }
+            think_time = TimeManagement::from_duration(ideal_think_time.min(max_think_time));
         }
 
         think_time.set_node_limit(node_limit);


### PR DESCRIPTION
Tested at 1m, no increment, no syzygy
```
princhess-sprt_gain_ltc-1  | Score of princhess vs princhess-main: 379 - 300 - 761  [0.527] 1440
princhess-sprt_gain_ltc-1  | ...      princhess playing White: 199 - 147 - 375  [0.536] 721
princhess-sprt_gain_ltc-1  | ...      princhess playing Black: 180 - 153 - 386  [0.519] 719
princhess-sprt_gain_ltc-1  | ...      White vs Black: 352 - 327 - 761  [0.509] 1440
princhess-sprt_gain_ltc-1  | Elo difference: 19.1 +/- 12.3, LOS: 99.9 %, DrawRatio: 52.8 %
princhess-sprt_gain_ltc-1  | SPRT: llr 2.1 (101.2%), lbound -1.5, ubound 2.08 - H1 was accepted
```