### PR TITLE
📦 NEW: Additional 70m data to value network

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -259,6 +259,13 @@ impl SearchTree {
         self.playouts.load(Ordering::Relaxed)
     }
 
+    pub fn depth(&self) -> usize {
+        match self.playouts() {
+            0 => 0,
+            _ => self.num_nodes() / self.playouts(),
+        }
+    }
+
     pub fn max_depth(&self) -> usize {
         self.max_depth.load(Ordering::Relaxed)
     }
@@ -470,7 +477,7 @@ impl SearchTree {
         let search_time_ms = time_management.elapsed().as_millis();
 
         let nodes = self.num_nodes();
-        let depth = nodes / self.playouts();
+        let depth = self.depth();
         let sel_depth = self.max_depth();
         let pv = self.principal_variation(depth.max(1));
         let pv_string: String = pv.into_iter().fold(String::new(), |mut out, x| {

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -3,17 +3,3 @@ mod value;
 
 pub use crate::train::data::TrainingPosition;
 pub use crate::train::value::ValueNetwork;
-
-use std::alloc::{self, Layout};
-use std::boxed::Box;
-
-fn boxed_and_zeroed<T>() -> Box<T> {
-    unsafe {
-        let layout = Layout::new::<T>();
-        let ptr = alloc::alloc_zeroed(layout);
-        if ptr.is_null() {
-            alloc::handle_alloc_error(layout);
-        }
-        Box::from_raw(ptr.cast())
-    }
-}

--- a/src/train/value.rs
+++ b/src/train/value.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Display, Formatter};
 use crate::evaluation;
 use crate::math::Rng;
 use crate::state;
-use crate::train::boxed_and_zeroed;
+use crate::mem::boxed_and_zeroed;
 
 const INPUT_SIZE: usize = state::VALUE_NUMBER_FEATURES;
 const HIDDEN_SIZE: usize = 512;


### PR DESCRIPTION
```
sprt_gain-1  | Score of princhess vs princhess-main: 2296 - 2128 - 3776  [0.510] 8200
sprt_gain-1  | ...      princhess playing White: 1168 - 1067 - 1865  [0.512] 4100
sprt_gain-1  | ...      princhess playing Black: 1128 - 1061 - 1911  [0.508] 4100
sprt_gain-1  | ...      White vs Black: 2229 - 2195 - 3776  [0.502] 8200
sprt_gain-1  | Elo difference: 7.1 +/- 5.5, LOS: 99.4 %, DrawRatio: 46.0 %
sprt_gain-1  | SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```