### PR TITLE
🐛 FIX: Child selection when visits zero

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -523,7 +523,7 @@ fn select_child_after_search(children: &[MoveEdge]) -> &MoveEdge {
         let visits = child.visits();
 
         if visits == 0 {
-            return -SCALE;
+            return - (2. * SCALE) + child.policy() as f32;
         }
 
         let sum_rewards = child.sum_rewards();


### PR DESCRIPTION
On PolicyOnly play
```
sprt_gain-1  | Score of princhess vs princhess-main: 690 - 559 - 925  [0.530] 2174
sprt_gain-1  | ...      princhess playing White: 342 - 288 - 457  [0.525] 1087
sprt_gain-1  | ...      princhess playing Black: 348 - 271 - 468  [0.535] 1087
sprt_gain-1  | ...      White vs Black: 613 - 636 - 925  [0.495] 2174
sprt_gain-1  | Elo difference: 21.0 +/- 11.1, LOS: 100.0 %, DrawRatio: 42.5 %
sprt_gain-1  | SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```