### PR TITLE
📦 NEW: 50 move rule damping

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -162,7 +162,7 @@ fn run_value_net(state: &State) -> f32 {
         result += relu(x) * i32::from(w);
     }
 
-    result = result * (200 - state.fifty_move_counter() as i32) / 200;
+    result -= result * (state.fifty_move_counter() - 36).max(0) as i32 / 128;
 
     (result as f32 / QAB as f32).tanh()
 }

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -162,6 +162,8 @@ fn run_value_net(state: &State) -> f32 {
         result += relu(x) * i32::from(w);
     }
 
+    result = result * (200 - state.fifty_move_counter() as i32) / 200;
+
     (result as f32 / QAB as f32).tanh()
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -131,6 +131,10 @@ impl State {
         self.prev_state_hashes.len()
     }
 
+    pub fn fifty_move_counter(&self) -> usize {
+        self.prev_state_hashes.len()
+    }
+
     #[must_use]
     pub fn drawn_by_fifty_move_rule(&self) -> bool {
         self.prev_state_hashes.len() >= 100


### PR DESCRIPTION
```
sprt_gain-1  | Score of princhess vs princhess-main: 1404 - 1259 - 2234  [0.515] 4897
sprt_gain-1  | ...      princhess playing White: 702 - 618 - 1128  [0.517] 2448
sprt_gain-1  | ...      princhess playing Black: 702 - 641 - 1106  [0.512] 2449
sprt_gain-1  | ...      White vs Black: 1343 - 1320 - 2234  [0.502] 4897
sprt_gain-1  | Elo difference: 10.3 +/- 7.2, LOS: 99.8 %, DrawRatio: 45.6 %
sprt_gain-1  | SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```