### PR TITLE
👌 IMP: Remove a use of Option<Piece>

### DIFF
--- a/src/chess/board.rs
+++ b/src/chess/board.rs
@@ -307,7 +307,7 @@ impl Board {
             self.toggle(color, Piece::ROOK, mov.to());
             self.toggle(color, Piece::ROOK, mov.to().with_file(rook_to));
         } else if mov.is_promotion() {
-            let promotion = mov.promotion().unwrap();
+            let promotion = mov.promotion();
 
             self.toggle(color, piece, mov.from());
             self.toggle(color, promotion, mov.to());

--- a/src/chess/mv.rs
+++ b/src/chess/mv.rs
@@ -29,7 +29,7 @@ impl Move {
         Self(
             Self::new(from, to).0
                 | Self::PROMO_FLAG
-                | ((piece_to_promotion_idx(promotion)) << Self::PROMO_SHIFT),
+                | (promotion.to_promotion_idx() << Self::PROMO_SHIFT),
         )
     }
 
@@ -64,17 +64,15 @@ impl Move {
         self.0 & Self::PROMO_FLAG == Self::PROMO_FLAG
     }
 
-    #[must_use]
-    pub fn promotion(self) -> Option<Piece> {
+    pub fn promotion(self) -> Piece {
         if self.is_promotion() {
-            Some(promotion_idx_to_piece(
-                (self.0 >> Self::PROMO_SHIFT) & Self::PROMO_MASK,
-            ))
+            Piece::from_promotion_idx((self.0 >> Self::PROMO_SHIFT) & Self::PROMO_MASK)
         } else {
-            None
+            Piece::NONE
         }
     }
 
+    #[must_use]
     pub fn to_uci(self) -> String {
         let from = self.from();
         let to = if self.is_castle() && !is_chess960() {
@@ -89,41 +87,8 @@ impl Move {
             self.to()
         };
 
-        let promotion = self
-            .promotion()
-            .map_or(String::new(), piece_to_promotion_char);
+        let promotion = self.promotion().to_promotion_char();
 
         format!("{from}{to}{promotion}")
-    }
-}
-
-fn piece_to_promotion_char(piece: Piece) -> String {
-    match piece {
-        Piece::QUEEN => "q",
-        Piece::ROOK => "r",
-        Piece::BISHOP => "b",
-        Piece::KNIGHT => "n",
-        _ => panic!("Invalid promotion piece: {piece:?}"),
-    }
-    .to_string()
-}
-
-fn piece_to_promotion_idx(piece: Piece) -> u16 {
-    match piece {
-        Piece::QUEEN => 0,
-        Piece::ROOK => 1,
-        Piece::BISHOP => 2,
-        Piece::KNIGHT => 3,
-        _ => panic!("Invalid promotion piece: {piece:?}"),
-    }
-}
-
-fn promotion_idx_to_piece(idx: u16) -> Piece {
-    match idx {
-        0 => Piece::QUEEN,
-        1 => Piece::ROOK,
-        2 => Piece::BISHOP,
-        3 => Piece::KNIGHT,
-        _ => panic!("Invalid promotion index: {idx}"),
     }
 }

--- a/src/chess/piece.rs
+++ b/src/chess/piece.rs
@@ -18,6 +18,39 @@ impl Piece {
     pub const fn index(self) -> usize {
         self.0 as usize
     }
+
+    pub fn from_promotion_idx(idx: u16) -> Piece {
+        match idx {
+            0 => Piece::KNIGHT,
+            1 => Piece::BISHOP,
+            2 => Piece::ROOK,
+            3 => Piece::QUEEN,
+            _ => panic!("Invalid promotion index: {idx}"),
+        }
+    }
+
+    #[must_use]
+    pub fn to_promotion_idx(self) -> u16 {
+        match self {
+            Piece::KNIGHT => 0,
+            Piece::BISHOP => 1,
+            Piece::ROOK => 2,
+            Piece::QUEEN => 3,
+            _ => panic!("Invalid promotion piece: {self:?}"),
+        }
+    }
+
+    #[must_use]
+    pub fn to_promotion_char(self) -> String {
+        match self {
+            Piece::QUEEN => "q",
+            Piece::ROOK => "r",
+            Piece::BISHOP => "b",
+            Piece::KNIGHT => "n",
+            _ => "",
+        }
+        .to_string()
+    }
 }
 
 impl From<Piece> for u8 {

--- a/src/math.rs
+++ b/src/math.rs
@@ -14,7 +14,7 @@ pub fn softmax(arr: &mut [f32], t: f32) {
 }
 
 fn max(arr: &[f32]) -> f32 {
-    let mut max = std::f32::NEG_INFINITY;
+    let mut max = f32::NEG_INFINITY;
     for x in arr {
         max = max.max(*x);
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -35,7 +35,7 @@ impl TimeManagement {
     pub fn from_duration(d: Duration) -> Self {
         let start = Instant::now();
         let end = Some(start + d);
-        let node_limit = std::usize::MAX;
+        let node_limit = usize::MAX;
 
         Self {
             start,
@@ -48,7 +48,7 @@ impl TimeManagement {
     pub fn infinite() -> Self {
         let start = Instant::now();
         let end = None;
-        let node_limit = std::usize::MAX;
+        let node_limit = usize::MAX;
 
         Self {
             start,
@@ -159,7 +159,7 @@ impl Search {
         let mut increment = Duration::ZERO;
         let mut remaining = None;
         let mut movestogo: Option<u32> = None;
-        let mut node_limit = std::usize::MAX;
+        let mut node_limit = usize::MAX;
 
         while let Some(s) = tokens.next() {
             match s {
@@ -194,7 +194,7 @@ impl Search {
                         .unwrap_or("")
                         .parse()
                         .ok()
-                        .unwrap_or(std::usize::MAX);
+                        .unwrap_or(usize::MAX);
                 }
                 _ => (),
             }
@@ -367,5 +367,5 @@ pub fn eval_in_cp(eval: f32) -> String {
         2. * eval
     };
 
-    format!("cp {}", (cps * 100.).round().max(-1000.).min(1000.) as i64)
+    format!("cp {}", (cps * 100.).round().clamp(-1000., 1000.) as i64)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -281,8 +281,8 @@ impl State {
         let flip_to = flip_square(to_sq);
 
         let adj_to = match mv.promotion() {
-            Some(Piece::KNIGHT) => Square::from_coords(flip_to.file(), Rank::_1),
-            Some(Piece::BISHOP | Piece::ROOK) => Square::from_coords(flip_to.file(), Rank::_2),
+            Piece::KNIGHT => Square::from_coords(flip_to.file(), Rank::_1),
+            Piece::BISHOP | Piece::ROOK => Square::from_coords(flip_to.file(), Rank::_2),
             _ => flip_to,
         };
 

--- a/src/tablebase/mod.rs
+++ b/src/tablebase/mod.rs
@@ -114,11 +114,11 @@ pub fn probe_best_move(b: &Board) -> Option<(Move, Wdl)> {
             (root & bindings::TB_RESULT_PROMOTES_MASK) >> bindings::TB_RESULT_PROMOTES_SHIFT;
 
         let promotion_role = match promotion {
-            bindings::TB_PROMOTES_QUEEN => Some(Piece::QUEEN),
-            bindings::TB_PROMOTES_ROOK => Some(Piece::ROOK),
-            bindings::TB_PROMOTES_BISHOP => Some(Piece::BISHOP),
-            bindings::TB_PROMOTES_KNIGHT => Some(Piece::KNIGHT),
-            _ => None,
+            bindings::TB_PROMOTES_QUEEN => Piece::QUEEN,
+            bindings::TB_PROMOTES_ROOK => Piece::ROOK,
+            bindings::TB_PROMOTES_BISHOP => Piece::BISHOP,
+            bindings::TB_PROMOTES_KNIGHT => Piece::KNIGHT,
+            _ => Piece::NONE,
         };
 
         for m in b.legal_moves() {

--- a/src/train/data.rs
+++ b/src/train/data.rs
@@ -195,7 +195,8 @@ impl From<&TrainingPosition> for State {
             move_to_optional(position.previous_moves[0]),
         ];
 
-        let board = Board::from_bitboards(colors, pieces, position.stm, Square::NONE, Castling::none());
+        let board =
+            Board::from_bitboards(colors, pieces, position.stm, Square::NONE, Castling::none());
 
         State::from_board_with_prev_moves(board, prev_moves)
     }


### PR DESCRIPTION
Sanity check against performance regression
```
sprt_equal-1  | Score of princhess vs princhess-main: 180 - 183 - 637  [0.498] 1000
sprt_equal-1  | ...      princhess playing White: 93 - 82 - 325  [0.511] 500
sprt_equal-1  | ...      princhess playing Black: 87 - 101 - 312  [0.486] 500
sprt_equal-1  | ...      White vs Black: 194 - 169 - 637  [0.512] 1000
sprt_equal-1  | Elo difference: -1.0 +/- 13.0, LOS: 43.7 %, DrawRatio: 63.7 %
sprt_equal-1  | SPRT: llr 0.167 (5.8%), lbound -2.25, ubound 2.89
```