### PR TITLE
📦 NEW: Use see threshold of +8

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -260,7 +260,7 @@ impl State {
             mi.set_from_defend(defends.contains(from_sq));
 
             if piece != Piece::PAWN && piece != Piece::KING {
-                mi.set_to_good_see(b.see(*mv, -108));
+                mi.set_to_good_see(b.see(*mv, 8));
             }
 
             mi


### PR DESCRIPTION
```
sprt_gain-1  | Score of princhess vs princhess-main: 590 - 487 - 1490  [0.520] 2567
sprt_gain-1  | ...      princhess playing White: 313 - 232 - 739  [0.532] 1284
sprt_gain-1  | ...      princhess playing Black: 277 - 255 - 751  [0.509] 1283
sprt_gain-1  | ...      White vs Black: 568 - 509 - 1490  [0.511] 2567
sprt_gain-1  | Elo difference: 13.9 +/- 8.7, LOS: 99.9 %, DrawRatio: 58.0 %
sprt_gain-1  | SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```