### PR TITLE
👌 IMP: Refactor rewards calculations

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -243,10 +243,33 @@ impl QuantizedPolicyNetwork {
     ) -> Box<Self> {
         let mut network = Self::zeroed();
 
-        network.from_weights = unsafe { mem::transmute(*from_weights) };
-        network.from_bias = unsafe { mem::transmute(*from_bias) };
-        network.to_weights = unsafe { mem::transmute(*to_weights) };
-        network.to_bias = unsafe { mem::transmute(*to_bias) };
+        network.from_weights = unsafe {
+            mem::transmute::<
+                [RawOutputWeights; MoveIndex::FROM_COUNT],
+                [QuantizedOutputWeights; MoveIndex::FROM_COUNT],
+            >(*from_weights)
+        };
+
+        network.from_bias = unsafe {
+            mem::transmute::<
+                [RawOutputBias; MoveIndex::FROM_COUNT],
+                [QuantizedOutputBias; MoveIndex::FROM_COUNT],
+            >(*from_bias)
+        };
+
+        network.to_weights = unsafe {
+            mem::transmute::<
+                [RawOutputWeights; MoveIndex::TO_COUNT],
+                [QuantizedOutputWeights; MoveIndex::TO_COUNT],
+            >(*to_weights)
+        };
+
+        network.to_bias = unsafe {
+            mem::transmute::<
+                [RawOutputBias; MoveIndex::TO_COUNT],
+                [QuantizedOutputBias; MoveIndex::TO_COUNT],
+            >(*to_bias)
+        };
 
         network
     }
@@ -296,8 +319,8 @@ impl QuantizedPolicyNetwork {
                 let from_weight = self.get_from_weights(from_idx, *f);
                 let to_weight = self.get_to_weights(to_idx, *f);
 
-                from.set(&from_weight);
-                to.set(&to_weight);
+                from.set(from_weight);
+                to.set(to_weight);
             }
 
             out.push(from.dot_relu(&to) as f32 / QAA as f32);

--- a/src/search.rs
+++ b/src/search.rs
@@ -136,7 +136,9 @@ impl Search {
 
         if mvs.len() == 1 {
             let uci_mv = mvs[0].to_uci();
-            println!("info depth 1 seldepth 1 nodes 1 nps 1 tbhits 0 score cp 0 time 1 pv {uci_mv}");
+            println!(
+                "info depth 1 seldepth 1 nodes 1 nps 1 tbhits 0 score cp 0 time 1 pv {uci_mv}"
+            );
             println!("bestmove {uci_mv}");
             return;
         } else if let Some((mv, wdl)) = tablebase::probe_best_move(state.board()) {
@@ -300,18 +302,18 @@ impl Search {
             evaluation::policy(root_state, &state_moves, get_policy_temperature());
 
         let mut moves: Vec<(&MoveEdge, f32)> = root_moves.iter().zip(state_moves_eval).collect();
-        moves.sort_by_key(|(h, e)| (h.average_reward().unwrap_or(*e) * SCALE) as i64);
+        moves.sort_by_key(|(h, e)| (h.reward().average, (e * SCALE) as i64));
         for (mov, e) in moves {
+            let reward = mov.reward();
+
             println!(
                 "info string {:7} M: {:5} P: {:>6} V: {:7} E: {:>6} ({:>8})",
                 format!("{}", mov.get_move().to_uci()),
                 format!("{:3.2}", e * 100.),
                 format!("{:3.2}", f32::from(mov.policy()) / SCALE * 100.),
                 mov.visits(),
-                mov.average_reward()
-                    .map_or("n/a".to_string(), |r| format!("{:3.2}", r / (SCALE / 100.))),
-                mov.average_reward()
-                    .map_or("n/a".to_string(), |r| eval_in_cp(r / SCALE))
+                format!("{:3.2}", reward.average as f32 / (SCALE / 100.)),
+                format!("{:3.2}", eval_in_cp(reward.average as f32 / SCALE))
             );
         }
     }

--- a/src/train/data.rs
+++ b/src/train/data.rs
@@ -157,10 +157,7 @@ impl From<&SearchTree> for TrainingPosition {
         assert!(max_visits == Self::MAX_VISITS);
 
         let pv = tree.best_edge();
-        let mut evaluation = match pv.visits() {
-            0 => 0,
-            v => pv.sum_rewards() / i64::from(v),
-        } as i32;
+        let mut evaluation = pv.reward().average;
 
         let best_move = *pv.get_move();
 

--- a/src/tree_policy.rs
+++ b/src/tree_policy.rs
@@ -4,7 +4,7 @@ use std::f32;
 use crate::search::SCALE;
 use crate::search_tree::MoveEdge;
 
-pub fn choose_child(moves: &[MoveEdge], cpuct: f32, cpuct_tau: f32, fpu: i64) -> &MoveEdge {
+pub fn choose_child(moves: &[MoveEdge], cpuct: f32, cpuct_tau: f32, fpu: i32) -> &MoveEdge {
     let total_visits = moves.iter().map(|v| u64::from(v.visits())).sum::<u64>() + 1;
 
     let explore_coef =
@@ -14,17 +14,17 @@ pub fn choose_child(moves: &[MoveEdge], cpuct: f32, cpuct_tau: f32, fpu: i64) ->
     let mut best_score = i64::MIN;
 
     for mov in moves {
-        let sum_rewards = mov.sum_rewards();
-        let child_visits = i64::from(mov.visits());
+        let reward = mov.reward();
         let policy_evaln = mov.policy();
 
-        let q = if child_visits > 0 {
-            sum_rewards / child_visits
+        let q = i64::from(if reward.visits > 0 {
+            reward.average
         } else {
             fpu
-        };
+        });
 
-        let u = explore_coef * i64::from(policy_evaln) / ((child_visits + 1) * SCALE as i64);
+        let u = explore_coef * i64::from(policy_evaln)
+            / ((i64::from(reward.visits) + 1) * SCALE as i64);
 
         let score = q + u;
 


### PR DESCRIPTION
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, 4moves_noob.epd):
sprt_equal-1  | Elo: -0.58 +/- 4.84, nElo: -1.02 +/- 8.42
sprt_equal-1  | LOS: 40.65 %, DrawRatio: 49.88 %, PairsRatio: 0.98
sprt_equal-1  | Games: 6540, Wins: 1151, Losses: 1162, Draws: 4227, Points: 3264.5 (49.92 %)
sprt_equal-1  | Ptnml(0-2): [85, 742, 1631, 723, 89], WL/DD Ratio: 0.18
sprt_equal-1  | LLR: 0.40 (-2.25, 2.89) [-5.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```