### PR TITLE
📦 NEW: Remove virtual loss

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -21,8 +21,6 @@ use crate::tree_policy;
 
 const MAX_PLAYOUT_LENGTH: usize = 256;
 
-const VIRTUAL_LOSS: i64 = SCALE as i64;
-
 pub struct SearchTree {
     root_node: PositionNode,
     root_state: State,
@@ -159,14 +157,11 @@ impl MoveEdge {
     }
 
     pub fn down(&self) {
-        self.sum_evaluations
-            .fetch_sub(VIRTUAL_LOSS, Ordering::Relaxed);
         self.visits.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn up(&self, evaln: i64) {
-        let delta = evaln + VIRTUAL_LOSS;
-        self.sum_evaluations.fetch_add(delta, Ordering::Relaxed);
+        self.sum_evaluations.fetch_add(evaln, Ordering::Relaxed);
     }
 
     pub fn replace(&self, other: &MoveEdge) {


### PR DESCRIPTION
Single thread:
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, 4moves_noob.epd):
sprt_gain-1  | Elo: 29.71 +/- 10.68, nElo: 47.32 +/- 16.93
sprt_gain-1  | LOS: 100.00 %, DrawRatio: 47.22 %, PairsRatio: 1.59
sprt_gain-1  | Games: 1618, Wins: 388, Losses: 250, Draws: 980, Points: 878.0 (54.26 %)
sprt_gain-1  | Ptnml(0-2): [18, 147, 382, 203, 59], WL/DD Ratio: 0.21
sprt_gain-1  | LLR: 2.91 (-2.25, 2.89) [0.00, 5.00]
sprt_gain-1  | --------------------------------------------------
```

2 threads:
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 2t, 128MB, 4moves_noob.epd):
sprt_gain-1  | Elo: 12.25 +/- 6.45, nElo: 21.00 +/- 11.04
sprt_gain-1  | LOS: 99.99 %, DrawRatio: 49.50 %, PairsRatio: 1.24
sprt_gain-1  | Games: 3802, Wins: 729, Losses: 595, Draws: 2478, Points: 1968.0 (51.76 %)
sprt_gain-1  | Ptnml(0-2): [42, 386, 941, 460, 72], WL/DD Ratio: 0.15
sprt_gain-1  | LLR: 2.90 (-2.25, 2.89) [0.00, 5.00]
sprt_gain-1  | --------------------------------------------------
```