### PR TITLE
📦 NEW: CPuct Jitter for non main search results

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -23,6 +23,7 @@ fn max(arr: &[f32]) -> f32 {
     max
 }
 
+#[must_use]
 pub struct Rng {
     seed: u64,
 }


### PR DESCRIPTION
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 2t, 128MB, 4moves_noob.epd):
sprt_gain-1  | Elo: 13.53 +/- 6.57, nElo: 25.20 +/- 12.21
sprt_gain-1  | LOS: 100.00 %, DrawRatio: 54.12 %, PairsRatio: 1.35
sprt_gain-1  | Games: 3108, Wins: 552, Losses: 431, Draws: 2125, Points: 1614.5 (51.95 %)
sprt_gain-1  | Ptnml(0-2): [24, 280, 841, 369, 40], WL/DD Ratio: 0.14
sprt_gain-1  | LLR: 2.90 (-2.25, 2.89) [0.00, 5.00]
sprt_gain-1  | --------------------------------------------------

```