### PR TITLE
📦 NEW: Guard mutex with atomic bool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+native:
+	cargo rustc --release --bin princhess -- -C target-cpu=native


### PR DESCRIPTION
Single thread:
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, 4moves_noob.epd):
sprt_equal-1  | Elo: 4.42 +/- 8.19, nElo: 7.69 +/- 14.26
sprt_equal-1  | LOS: 85.48 %, DrawRatio: 51.84 %, PairsRatio: 1.08
sprt_equal-1  | Games: 2280, Wins: 383, Losses: 354, Draws: 1543, Points: 1154.5 (50.64 %)
sprt_equal-1  | Ptnml(0-2): [30, 234, 591, 247, 38], WL/DD Ratio: 0.11
sprt_equal-1  | LLR: 0.96 (-2.25, 2.89) [-5.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```