### PR TITLE
📦 NEW: Add hashful to info output

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -33,7 +33,11 @@ impl Arena {
         }
     }
 
-    pub fn full(&self) -> bool {
+    pub fn full(&self) -> usize {
+        self.owned_mappings.lock().unwrap().len() * 1000 / self.max_chunks
+    }
+
+    pub fn is_full(&self) -> bool {
         let owned_mappings = self.owned_mappings.lock().unwrap();
         owned_mappings.len() > self.max_chunks
     }

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -360,7 +360,8 @@ impl SearchTree {
             let new_node = match self.descend(&state, choice, tld) {
                 Ok(r) => r,
                 Err(ArenaError::Full) => {
-                    self.ttable.flip_if_full(|| self.root_node.clear_children_links());
+                    self.ttable
+                        .flip_if_full(|| self.root_node.clear_children_links());
                     return true;
                 }
             };
@@ -499,12 +500,13 @@ impl SearchTree {
             let eval = eval_in_cp(edge.reward().average as f32 / SCALE);
 
             let info_str = format!(
-                "info depth {} seldepth {} nodes {} nps {} tbhits {} score {} time {} multipv {} pv {}",
+                "info depth {} seldepth {} nodes {} nps {} tbhits {} hashful {} score {} time {} multipv {} pv {}",
                 depth.max(1),
                 sel_depth.max(1),
                 nodes,
                 nps,
                 self.tb_hits(),
+                self.ttable.full(),
                 eval,
                 search_time_ms,
                 idx + 1,

--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -36,6 +36,11 @@ impl TranspositionTable {
     }
 
     #[must_use]
+    pub fn full(&self) -> usize {
+        self.arena.full()
+    }
+
+    #[must_use]
     pub fn arena(&self) -> &Arena {
         &self.arena
     }
@@ -109,6 +114,10 @@ impl LRTable {
         Self::new(TranspositionTable::empty(), TranspositionTable::empty())
     }
 
+    pub fn full(&self) -> usize {
+        (self.left.arena().full() + self.right.arena().full()) / 2
+    }
+
     pub fn insert<'a>(&'a self, key: &State, value: &'a PositionNode) -> &'a PositionNode {
         self.current_table().insert(key, value)
     }
@@ -170,7 +179,7 @@ impl LRTable {
         {
             let _lock = self.flip_lock.lock().unwrap();
 
-            if self.current_table().arena().full() {
+            if self.current_table().arena().is_full() {
                 self.flip_tables();
                 f();
             }


### PR DESCRIPTION
Sanity check
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, 4moves_noob.epd):
sprt_equal-1  | Elo: 8.69 +/- 27.04, nElo: 15.51 +/- 48.15
sprt_equal-1  | LOS: 73.60 %, DrawRatio: 52.00 %, PairsRatio: 1.09
sprt_equal-1  | Games: 200, Wins: 34, Losses: 29, Draws: 137, Points: 102.5 (51.25 %)
sprt_equal-1  | Ptnml(0-2): [1, 22, 52, 21, 4], WL/DD Ratio: 0.11
sprt_equal-1  | LLR: 0.15 (-2.25, 2.89) [-5.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```