### PR TITLE
📦 NEW: Use moves_left estimate in time management

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -96,6 +96,7 @@ static POLICY_TEMPERATURE_ROOT: UciOption =
     UciOption::spin("PolicyTemperatureRoot", 1450, 0, 2 << 16);
 static CHESS960: UciOption = UciOption::check("UCI_Chess960", false);
 static POLICY_ONLY: UciOption = UciOption::check("PolicyOnly", false);
+static SHOW_MOVESLEFT: UciOption = UciOption::check("UCI_ShowMovesLeft", false);
 
 static ALL_OPTIONS: &[UciOption] = &[
     HASH,
@@ -109,6 +110,7 @@ static ALL_OPTIONS: &[UciOption] = &[
     POLICY_TEMPERATURE_ROOT,
     CHESS960,
     POLICY_ONLY,
+    SHOW_MOVESLEFT,
 ];
 
 pub struct UciOptionMap {
@@ -183,6 +185,7 @@ pub struct SearchOptions {
     pub multi_pv: usize,
     pub is_chess960: bool,
     pub is_policy_only: bool,
+    pub show_movesleft: bool,
     pub mcts_options: MctsOptions,
 }
 
@@ -212,6 +215,7 @@ impl From<&UciOptionMap> for SearchOptions {
             multi_pv: map.get_and(&MULTI_PV, |s| s.parse().ok()),
             is_chess960: map.get_and(&CHESS960, |s| s.parse().ok()),
             is_policy_only: map.get_and(&POLICY_ONLY, |s| s.parse().ok()),
+            show_movesleft: map.get_and(&SHOW_MOVESLEFT, |s| s.parse().ok()),
             mcts_options: MctsOptions::from(map),
         }
     }

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -467,6 +467,8 @@ impl SearchTree {
     }
 
     pub fn print_info(&self, time_management: &TimeManagement) {
+        let mut info_str = String::with_capacity(256);
+
         let search_time_ms = time_management.elapsed().as_millis();
 
         let nodes = self.num_nodes();
@@ -486,34 +488,38 @@ impl SearchTree {
         let is_chess960 = self.search_options.is_chess960;
 
         for (idx, edge) in moves.iter().enumerate().take(self.search_options.multi_pv) {
+            info_str.push_str("info ");
+            write!(info_str, "depth {} ", depth.max(1)).unwrap();
+            write!(info_str, "seldepth {} ", sel_depth.max(1)).unwrap();
+            write!(info_str, "nodes {nodes} ").unwrap();
+            write!(info_str, "nps {nps} ").unwrap();
+            write!(info_str, "tbhits {} ", self.tb_hits()).unwrap();
+            write!(info_str, "hashfull {} ", self.ttable.full()).unwrap();
+
+            if self.search_options.show_movesleft {
+                write!(info_str, "movesleft {} ", self.root_state.moves_left()).unwrap();
+            }
+
+            write!(
+                info_str,
+                "score {} ",
+                eval_in_cp(self.best_edge().reward().average as f32 / SCALE)
+            )
+            .unwrap();
+            write!(info_str, "time {search_time_ms} ").unwrap();
+            write!(info_str, "multipv {} ", idx + 1).unwrap();
+
             let pv = match edge.child() {
                 Some(child) => principal_variation(child, depth.max(1) - 1),
                 None => vec![],
             };
 
-            let pv_string: String =
-                pv.into_iter()
-                    .fold(edge.get_move().to_uci(is_chess960), |mut out, x| {
-                        write!(out, " {}", x.get_move().to_uci(is_chess960)).unwrap();
-                        out
-                    });
+            write!(info_str, "pv {}", edge.get_move().to_uci(is_chess960)).unwrap();
 
-            let eval = eval_in_cp(edge.reward().average as f32 / SCALE);
+            for m in &pv {
+                write!(info_str, " {}", m.get_move().to_uci(is_chess960)).unwrap();
+            }
 
-            let info_str = format!(
-                "info depth {} seldepth {} nodes {} nps {} tbhits {} hashfull {} movesleft {}, score {} time {} multipv {} pv {}",
-                depth.max(1),
-                sel_depth.max(1),
-                nodes,
-                nps,
-                self.tb_hits(),
-                self.ttable.full(),
-                self.root_state.moves_left(),
-                eval,
-                search_time_ms,
-                idx + 1,
-                pv_string,
-            );
             println!("{info_str}");
         }
     }

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -501,13 +501,14 @@ impl SearchTree {
             let eval = eval_in_cp(edge.reward().average as f32 / SCALE);
 
             let info_str = format!(
-                "info depth {} seldepth {} nodes {} nps {} tbhits {} hashful {} score {} time {} multipv {} pv {}",
+                "info depth {} seldepth {} nodes {} nps {} tbhits {} hashfull {} movesleft {}, score {} time {} multipv {} pv {}",
                 depth.max(1),
                 sel_depth.max(1),
                 nodes,
                 nps,
                 self.tb_hits(),
                 self.ttable.full(),
+                self.root_state.moves_left(),
                 eval,
                 search_time_ms,
                 idx + 1,

--- a/src/state.rs
+++ b/src/state.rs
@@ -106,6 +106,16 @@ impl State {
     }
 
     #[must_use]
+    #[allow(clippy::cast_sign_loss)]
+    pub fn moves_left(&self) -> u16 {
+        let p = f32::from(
+            (self.board.fullmove_counter() - 1) * 2
+                + u16::from(self.side_to_move() == Color::BLACK),
+        );
+        (59.3 + (72830.0 - p * 2330.0) / (p * p + p * 10.0 + 2644.0)) as u16 / 2
+    }
+
+    #[must_use]
     pub fn halfmove_clock(&self) -> u8 {
         self.board.halfmove_clock()
     }


### PR DESCRIPTION
Uses formula proposed in https://expositor.dev/pdf/movetime.pdf

LTC:
```
sprt_gain_ltc-1  | --------------------------------------------------
sprt_gain_ltc-1  | Results of princhess vs princhess-main (40+0.4, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain_ltc-1  | Elo: 10.78 +/- 6.85, nElo: 19.80 +/- 12.57
sprt_gain_ltc-1  | LOS: 99.90 %, DrawRatio: 49.76 %, PairsRatio: 1.22
sprt_gain_ltc-1  | Games: 2934, Wins: 669, Losses: 578, Draws: 1687, Points: 1512.5 (51.55 %)
sprt_gain_ltc-1  | Ptnml(0-2): [14, 318, 730, 373, 32], WL/DD Ratio: 0.47
sprt_gain_ltc-1  | LLR: 2.09 (-1.50, 2.08) [0.00, 5.00]
sprt_gain_ltc-1  | --------------------------------------------------
```

STC:
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 1.62 +/- 5.27, nElo: 2.70 +/- 8.79
sprt_equal-1  | LOS: 72.66 %, DrawRatio: 44.70 %, PairsRatio: 1.04
sprt_equal-1  | Games: 6000, Wins: 1482, Losses: 1454, Draws: 3064, Points: 3014.0 (50.23 %)
sprt_equal-1  | Ptnml(0-2): [85, 729, 1341, 763, 82], WL/DD Ratio: 0.71
sprt_equal-1  | LLR: 1.29 (-2.25, 2.89) [-5.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```