### PR TITLE
📦 NEW: Use SCreLU for value net

### DIFF
--- a/src/chess/board.rs
+++ b/src/chess/board.rs
@@ -104,13 +104,13 @@ impl Board {
         board.ep = ep;
         board.castling = castling;
 
-        board.hash = board.generate_zobrist_hash();
-
         for (idx, pc) in pieces.iter().enumerate() {
             for sq in *pc {
                 board.piece_at[sq] = Piece::from(idx);
             }
         }
+
+        board.hash = board.generate_zobrist_hash();
 
         board
     }


### PR DESCRIPTION
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain-1  | Elo: 21.95 +/- 11.92, nElo: 38.59 +/- 20.90
sprt_gain-1  | LOS: 99.99 %, DrawRatio: 48.59 %, PairsRatio: 1.53
sprt_gain-1  | Games: 1062, Wins: 297, Losses: 230, Draws: 535, Points: 564.5 (53.15 %)
sprt_gain-1  | Ptnml(0-2): [8, 100, 258, 147, 18], WL/DD Ratio: 0.79
sprt_gain-1  | LLR: 2.90 (-2.25, 2.89) [0.00, 10.00]
sprt_gain-1  | --------------------------------------------------
```