### PR TITLE
📦 NEW: New policy net with 5k visits datagen

### DIFF
--- a/src/bin/data-gen.rs
+++ b/src/bin/data-gen.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const HASH_SIZE_MB: usize = 128;
 
-const VISITS_PER_POSITION: u64 = 3000;
+const VISITS_PER_POSITION: u64 = 5000;
 const THREADS: u64 = 5;
 const DFRC_PCT: u64 = 10;
 


### PR DESCRIPTION
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain-1  | Elo: 7.48 +/- 5.94, nElo: 12.57 +/- 9.99
sprt_gain-1  | LOS: 99.32 %, DrawRatio: 46.00 %, PairsRatio: 1.17
sprt_gain-1  | Games: 4648, Wins: 1181, Losses: 1081, Draws: 2386, Points: 2374.0 (51.08 %)
sprt_gain-1  | Ptnml(0-2): [65, 513, 1069, 611, 66], WL/DD Ratio: 0.69
sprt_gain-1  | LLR: 2.91 (-2.25, 2.89) [0.00, 10.00]
sprt_gain-1  | --------------------------------------------------
```