### PR TITLE
📦 NEW: Use pv eval for time management

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -100,6 +100,8 @@ static TM_MIN_M: UciOption = UciOption::spin("TMMinM", 10, 0, 2 << 16);
 static TM_MAX_M: UciOption = UciOption::spin("TMMaxM", 500, 0, 2 << 16);
 static TM_VISITS_BASE: UciOption = UciOption::spin("TMVisitsBase", 140, 0, 2 << 16);
 static TM_VISITS_M: UciOption = UciOption::spin("TMVisitsM", 139, 0, 2 << 16);
+static TM_PV_DIFF_C: UciOption = UciOption::spin("TMPvDiffC", 20, 0, 100);
+static TM_PV_DIFF_M: UciOption = UciOption::spin("TMPvDiffM", 461, 0, 2 << 16);
 
 static CHESS960: UciOption = UciOption::check("UCI_Chess960", false);
 static POLICY_ONLY: UciOption = UciOption::check("PolicyOnly", false);
@@ -119,6 +121,8 @@ static ALL_OPTIONS: &[UciOption] = &[
     TM_MAX_M,
     TM_VISITS_BASE,
     TM_VISITS_M,
+    TM_PV_DIFF_C,
+    TM_PV_DIFF_M,
     CHESS960,
     POLICY_ONLY,
     SHOW_MOVESLEFT,
@@ -208,6 +212,8 @@ pub struct TimeManagementOptions {
     pub max_m: f32,
     pub visits_base: f32,
     pub visits_m: f32,
+    pub pv_diff_c: f32,
+    pub pv_diff_m: f32,
 }
 
 impl Default for MctsOptions {
@@ -234,6 +240,8 @@ impl From<&UciOptionMap> for TimeManagementOptions {
             max_m: map.get_f32(&TM_MAX_M),
             visits_base: map.get_f32(&TM_VISITS_BASE),
             visits_m: map.get_f32(&TM_VISITS_M),
+            pv_diff_c: map.get_f32(&TM_PV_DIFF_C),
+            pv_diff_m: map.get_f32(&TM_PV_DIFF_M),
         }
     }
 }


### PR DESCRIPTION
LTC:
```
sprt_gain_ltc-1  | --------------------------------------------------
sprt_gain_ltc-1  | Results of princhess vs princhess-main (40+0.4, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain_ltc-1  | Elo: 4.61 +/- 4.41, nElo: 9.25 +/- 8.83
sprt_gain_ltc-1  | LOS: 98.00 %, DrawRatio: 55.50 %, PairsRatio: 1.12
sprt_gain_ltc-1  | Games: 5950, Wins: 1222, Losses: 1143, Draws: 3585, Points: 3014.5 (50.66 %)
sprt_gain_ltc-1  | Ptnml(0-2): [24, 601, 1651, 670, 29], WL/DD Ratio: 0.43
sprt_gain_ltc-1  | LLR: 2.09 (-1.50, 2.08) [0.00, 10.00]
sprt_gain_ltc-1  | --------------------------------------------------
```

STC:
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 6.19 +/- 8.07, nElo: 11.18 +/- 14.56
sprt_equal-1  | LOS: 93.38 %, DrawRatio: 50.55 %, PairsRatio: 1.10
sprt_equal-1  | Games: 2188, Wins: 487, Losses: 448, Draws: 1253, Points: 1113.5 (50.89 %)
sprt_equal-1  | Ptnml(0-2): [15, 243, 553, 254, 29], WL/DD Ratio: 0.46
sprt_equal-1  | LLR: 2.92 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```