### PR TITLE
👌 IMP: Clippy Fixes

### DIFF
--- a/src/chess/attacks.rs
+++ b/src/chess/attacks.rs
@@ -31,6 +31,7 @@ const fn sliding_attacks(square: i32, occupied: u64, deltas: &[i32]) -> u64 {
     attack
 }
 
+#[allow(clippy::large_stack_arrays)]
 const fn init_in_between() -> [[Bitboard; 64]; 64] {
     let mut arr = [[Bitboard::EMPTY; 64]; 64];
     let mut from = 0;
@@ -61,6 +62,7 @@ const fn in_between(sq1: usize, sq2: usize) -> Bitboard {
     Bitboard::new(line & btwn)
 }
 
+#[allow(clippy::large_stack_arrays)]
 const fn init_line_through() -> [[Bitboard; 64]; 64] {
     let mut arr = [[Bitboard::EMPTY; 64]; 64];
     let mut from = 0;
@@ -190,8 +192,8 @@ const KING_ATTACKS: [Bitboard; 64] = init_king_attacks();
 
 static SLIDING_ATTACKS: [Bitboard; 88772] = init_sliding_attacks();
 
-const IN_BETWEEN: [[Bitboard; 64]; 64] = init_in_between();
-const LINE_THROUGH: [[Bitboard; 64]; 64] = init_line_through();
+static IN_BETWEEN: [[Bitboard; 64]; 64] = init_in_between();
+static LINE_THROUGH: [[Bitboard; 64]; 64] = init_line_through();
 
 const DIAGS: [u64; 15] = [
     0x0100_0000_0000_0000,


### PR DESCRIPTION
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: -0.05 +/- 4.37, nElo: -0.09 +/- 8.07
sprt_equal-1  | LOS: 49.13 %, DrawRatio: 50.65 %, PairsRatio: 1.01
sprt_equal-1  | Games: 7116, Wins: 1547, Losses: 1548, Draws: 4021, Points: 3557.5 (49.99 %)
sprt_equal-1  | Ptnml(0-2): [62, 810, 1802, 835, 49], WL/DD Ratio: 0.52
sprt_equal-1  | LLR: 2.89 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```