### PR TITLE
📦 NEW: More epochs for policy

### DIFF
--- a/src/bin/train-policy.rs
+++ b/src/bin/train-policy.rs
@@ -11,7 +11,7 @@ use princhess::policy::{PolicyCount, PolicyNetwork};
 use princhess::state::State;
 use princhess::train::TrainingPosition;
 
-const TARGET_BATCH_COUNT: usize = 200_000;
+const TARGET_BATCH_COUNT: usize = 300_000;
 const BATCH_SIZE: usize = 16384;
 const THREADS: usize = 6;
 


### PR DESCRIPTION
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain-1  | Elo: 3.10 +/- 3.25, nElo: 5.32 +/- 5.56
sprt_gain-1  | LOS: 96.96 %, DrawRatio: 47.12 %, PairsRatio: 1.06
sprt_gain-1  | Games: 15000, Wins: 3613, Losses: 3479, Draws: 7908, Points: 7567.0 (50.45 %)
sprt_gain-1  | Ptnml(0-2): [184, 1739, 3534, 1845, 198], WL/DD Ratio: 0.63
sprt_gain-1  | LLR: 0.39 (-2.25, 2.89) [0.00, 10.00]
sprt_gain-1  | --------------------------------------------------
```