### PR TITLE
📦 NEW: Use default mcts options for data gen

### DIFF
--- a/src/bin/data-gen.rs
+++ b/src/bin/data-gen.rs
@@ -27,11 +27,6 @@ const DFRC_PCT: u64 = 10;
 
 const MAX_POSITIONS_PER_FILE: u64 = 20_000_000;
 const MAX_POSITIONS_TOTAL: u64 = MAX_POSITIONS_PER_FILE * THREADS;
-
-const CPUCT: f32 = 2.82;
-const CPUCT_TAU: f32 = 0.5;
-const POLICY_TEMPERATURE: f32 = 1.0;
-const POLICY_TEMPERATURE_ROOT: f32 = 1.1;
 const MAX_VARIATIONS: usize = 16;
 
 struct Stats {
@@ -208,12 +203,7 @@ fn run_game(stats: &Stats, positions: &mut Vec<TrainingPosition>, rng: &mut Rng)
 
     variations.push(random_start(rng));
 
-    let mcts_options = MctsOptions {
-        cpuct: CPUCT,
-        cpuct_tau: CPUCT_TAU,
-        policy_temperature: POLICY_TEMPERATURE,
-        policy_temperature_root: POLICY_TEMPERATURE_ROOT,
-    };
+    let mcts_options = MctsOptions::default();
 
     let search_options = SearchOptions {
         mcts_options,


### PR DESCRIPTION
STC:
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain-1  | Elo: 4.05 +/- 3.31, nElo: 6.80 +/- 5.56
sprt_gain-1  | LOS: 99.17 %, DrawRatio: 46.13 %, PairsRatio: 1.06
sprt_gain-1  | Games: 15000, Wins: 3668, Losses: 3493, Draws: 7839, Points: 7587.5 (50.58 %)
sprt_gain-1  | Ptnml(0-2): [189, 1770, 3460, 1839, 242], WL/DD Ratio: 0.64
sprt_gain-1  | LLR: 2.24 (-2.25, 2.89) [0.00, 10.00]
sprt_gain-1  | --------------------------------------------------
```

LTC:
```
sprt_gain_ltc-1  | --------------------------------------------------
sprt_gain_ltc-1  | Results of princhess vs princhess-main (40+0.4, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain_ltc-1  | Elo: 13.95 +/- 10.68, nElo: 24.73 +/- 18.92
sprt_gain_ltc-1  | LOS: 99.48 %, DrawRatio: 47.38 %, PairsRatio: 1.32
sprt_gain_ltc-1  | Games: 1296, Wins: 320, Losses: 268, Draws: 708, Points: 674.0 (52.01 %)
sprt_gain_ltc-1  | Ptnml(0-2): [10, 137, 307, 179, 15], WL/DD Ratio: 0.57
sprt_gain_ltc-1  | LLR: 2.10 (-1.50, 2.08) [0.00, 10.00]
sprt_gain_ltc-1  | --------------------------------------------------
```