### PR TITLE
📦 NEW: Capacity check on arena before first allocation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,8 @@ services:
       -each proto=uci tc=8+0.08
             option.SyzygyPath=/syzygy option.Hash=128 option.Threads=1
       -openings file=/books/8moves_v3.epd format=epd order=random
-      -debug -rounds 1
+      -rounds 1
+      -log file=pgn/debug.log
       -pgnout /pgn/debug.pgn
     volumes:
       - ./target/release/princhess:/engines/princhess

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -59,6 +59,10 @@ impl Arena {
         self.used() >= self.max
     }
 
+    pub fn capacity_remaining(&self) -> usize {
+        self.max - self.used()
+    }
+
     fn try_alloc_chunk(&self, id: u64) -> Result<&mut [u8], Error> {
         if self.is_full() {
             return Err(Error::Full);

--- a/src/search.rs
+++ b/src/search.rs
@@ -266,6 +266,11 @@ impl Search {
             while self.search_tree.playout(&mut tld, cpuct, tm, &stop_signal) {}
         };
 
+        if self.search_tree.table_capacity_remaining() < threads.thread_count() as usize {
+            self.search_tree.flip_tables();
+            self.search_tree.root_node().clear_children_links();
+        }
+
         threads.scoped(|s| {
             s.execute(|| {
                 run_search_thread(cpuct, &time_management);

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -253,6 +253,14 @@ impl SearchTree {
         self.ttable
     }
 
+    pub fn table_capacity_remaining(&self) -> usize {
+        self.ttable.capacity_remaining()
+    }
+
+    pub fn flip_tables(&self) {
+        self.ttable.flip_tables();
+    }
+
     pub fn num_nodes(&self) -> usize {
         self.num_nodes.load(Ordering::Relaxed)
     }

--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -122,6 +122,10 @@ impl LRTable {
         (self.left.arena().full() + self.right.arena().full()) / 2
     }
 
+    pub fn capacity_remaining(&self) -> usize {
+        self.current_table().arena().capacity_remaining()
+    }
+
     pub fn insert<'a>(&'a self, key: &State, value: &'a PositionNode) -> &'a PositionNode {
         self.current_table().insert(key, value)
     }


### PR DESCRIPTION
1t:
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 2.49 +/- 5.99, nElo: 4.70 +/- 11.31
sprt_equal-1  | LOS: 79.22 %, DrawRatio: 51.54 %, PairsRatio: 1.04
sprt_equal-1  | Games: 3628, Wins: 742, Losses: 716, Draws: 2170, Points: 1827.0 (50.36 %)
sprt_equal-1  | Ptnml(0-2): [19, 412, 935, 420, 28], WL/DD Ratio: 0.40
sprt_equal-1  | LLR: 2.91 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```

2t:
```
sprt_gain_2t-1  | --------------------------------------------------
sprt_gain_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_gain_2t-1  | Elo: 1.60 +/- 5.39, nElo: 3.07 +/- 10.34
sprt_gain_2t-1  | LOS: 71.98 %, DrawRatio: 54.33 %, PairsRatio: 1.04
sprt_gain_2t-1  | Games: 4340, Wins: 948, Losses: 928, Draws: 2464, Points: 2180.0 (50.23 %)
sprt_gain_2t-1  | Ptnml(0-2): [31, 455, 1179, 473, 32], WL/DD Ratio: 0.54
sprt_gain_2t-1  | LLR: 2.90 (-2.25, 2.89) [-10.00, 0.00]
sprt_gain_2t-1  | --------------------------------------------------
```