### PR TITLE
🐛 FIX: Tighten up allocation

### DIFF
--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -219,8 +219,8 @@ impl<'a> LRAllocator<'a> {
     ) -> Self {
         Self {
             is_left_current,
-            left: left.allocator(),
-            right: right.allocator(),
+            left: left.invalid_allocator(),
+            right: right.invalid_allocator(),
         }
     }
 


### PR DESCRIPTION
Attempt to fix crashes that occur at TCEC scale, by being a bit more rigorous with memory/threading.