### PR TITLE
🐛 FIX: Ensure node and edge allocated in same arena

### DIFF
--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -243,19 +243,19 @@ impl<'a> LRAllocator<'a> {
         self.is_left_current.load(Ordering::Relaxed)
     }
 
-    pub fn alloc_node(&self) -> Result<&'a mut PositionNode, ArenaError> {
-        if self.is_left_current() {
-            self.left.alloc_one()
+    pub fn alloc_node(
+        &self,
+        edges: usize,
+    ) -> Result<(&'a mut PositionNode, &'a mut [MoveEdge]), ArenaError> {
+        let alloc = if self.is_left_current() {
+            &self.left
         } else {
-            self.right.alloc_one()
-        }
-    }
+            &self.right
+        };
 
-    pub fn alloc_move_info(&self, sz: usize) -> Result<&'a mut [MoveEdge], ArenaError> {
-        if self.is_left_current() {
-            self.left.alloc_slice(sz)
-        } else {
-            self.right.alloc_slice(sz)
-        }
+        let edges = alloc.alloc_slice(edges)?;
+        let node = alloc.alloc_one()?;
+
+        Ok((node, edges))
     }
 }


### PR DESCRIPTION
1t:
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 4.38 +/- 6.96, nElo: 8.24 +/- 13.11
sprt_equal-1  | LOS: 89.11 %, DrawRatio: 53.11 %, PairsRatio: 1.09
sprt_equal-1  | Games: 2700, Wins: 589, Losses: 555, Draws: 1556, Points: 1367.0 (50.63 %)
sprt_equal-1  | Ptnml(0-2): [18, 285, 717, 305, 25], WL/DD Ratio: 0.48
sprt_equal-1  | LLR: 2.95 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```

2t:
```
sprt_gain_2t-1  | --------------------------------------------------
sprt_gain_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_gain_2t-1  | Elo: 7.72 +/- 8.67, nElo: 14.12 +/- 15.85
sprt_gain_2t-1  | LOS: 95.96 %, DrawRatio: 48.86 %, PairsRatio: 1.20
sprt_gain_2t-1  | Games: 1846, Wins: 412, Losses: 371, Draws: 1063, Points: 943.5 (51.11 %)
sprt_gain_2t-1  | Ptnml(0-2): [14, 201, 451, 244, 13], WL/DD Ratio: 0.46
sprt_gain_2t-1  | LLR: 2.91 (-2.25, 2.89) [-10.00, 0.00]
sprt_gain_2t-1  | --------------------------------------------------
```