### PR TITLE
📦 NEW: Use boxed slice for arena

### DIFF
--- a/src/chess/board.rs
+++ b/src/chess/board.rs
@@ -115,6 +115,7 @@ impl Board {
         board
     }
 
+    #[allow(clippy::many_single_char_names)]
     pub fn from_fen(fen: &str) -> Self {
         let mut board = Self::empty();
 
@@ -124,7 +125,7 @@ impl Board {
             match parts.as_slice() {
                 [a, b, c, d, e, f] => (*a, *b, *c, *d, *e, *f),
                 [a, b, c, d] => (*a, *b, *c, *d, "0", "0"),
-                _ =>  {
+                _ => {
                     println!("info string invalid fen");
                     return board;
                 }


### PR DESCRIPTION
1t:
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 0.33 +/- 4.59, nElo: 0.63 +/- 8.61
sprt_equal-1  | LOS: 55.66 %, DrawRatio: 52.09 %, PairsRatio: 0.98
sprt_equal-1  | Games: 6254, Wins: 1321, Losses: 1315, Draws: 3618, Points: 3130.0 (50.05 %)
sprt_equal-1  | Ptnml(0-2): [35, 722, 1629, 684, 57], WL/DD Ratio: 0.47
sprt_equal-1  | LLR: 2.91 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```

2t:
```
sprt_gain_2t-1  | --------------------------------------------------
sprt_gain_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_gain_2t-1  | Elo: 4.22 +/- 7.07, nElo: 7.69 +/- 12.87
sprt_gain_2t-1  | LOS: 87.92 %, DrawRatio: 49.96 %, PairsRatio: 1.06
sprt_gain_2t-1  | Games: 2798, Wins: 619, Losses: 585, Draws: 1594, Points: 1416.0 (50.61 %)
sprt_gain_2t-1  | Ptnml(0-2): [17, 323, 699, 329, 31], WL/DD Ratio: 0.48
sprt_gain_2t-1  | LLR: 2.93 (-2.25, 2.89) [-10.00, 0.00]
sprt_gain_2t-1  | --------------------------------------------------
```