### PR TITLE
📦 NEW: New value net

### DIFF
--- a/src/bin/train-value.rs
+++ b/src/bin/train-value.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::thread;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-const TARGET_BATCH_COUNT: usize = 250_000;
+const TARGET_BATCH_COUNT: usize = 400_000;
 const BATCH_SIZE: usize = 16384;
 const THREADS: usize = 6;
 


### PR DESCRIPTION
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain-1  | Elo: 5.26 +/- 4.21, nElo: 8.50 +/- 6.80
sprt_gain-1  | LOS: 99.29 %, DrawRatio: 43.52 %, PairsRatio: 1.11
sprt_gain-1  | Games: 10032, Wins: 2601, Losses: 2449, Draws: 4982, Points: 5092.0 (50.76 %)
sprt_gain-1  | Ptnml(0-2): [166, 1178, 2183, 1316, 173], WL/DD Ratio: 0.75
sprt_gain-1  | LLR: 2.91 (-2.25, 2.89) [0.00, 10.00]
sprt_gain-1  | --------------------------------------------------
```