### PR TITLE
🐛 FIX: Use Acquire/Release instead of Relaxed for AtomicPtr

### DIFF
--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -147,7 +147,7 @@ impl LRTable {
     }
 
     pub fn is_left_current(&self) -> bool {
-        self.is_left_current.load(Ordering::Relaxed)
+        self.is_left_current.load(Ordering::Acquire)
     }
 
     pub fn generation(&self) -> u64 {
@@ -172,10 +172,7 @@ impl LRTable {
 
     fn flip_tables(&self) {
         self.previous_table().clear();
-        self.is_left_current.store(
-            !self.is_left_current.load(Ordering::Relaxed),
-            Ordering::Relaxed,
-        );
+        self.is_left_current.fetch_not(Ordering::Release);
         self.generation.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -247,7 +244,7 @@ impl<'a> LRAllocator<'a> {
     }
 
     fn is_left_current(&self) -> bool {
-        self.is_left_current.load(Ordering::Relaxed)
+        self.is_left_current.load(Ordering::Acquire)
     }
 
     pub fn alloc_node(


### PR DESCRIPTION
```
sprt_equal_2t-1  | --------------------------------------------------
sprt_equal_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_equal_2t-1  | Elo: 2.53 +/- 6.01, nElo: 4.80 +/- 11.40
sprt_equal_2t-1  | LOS: 79.55 %, DrawRatio: 52.94 %, PairsRatio: 1.06
sprt_equal_2t-1  | Games: 3566, Wins: 761, Losses: 735, Draws: 2070, Points: 1796.0 (50.36 %)
sprt_equal_2t-1  | Ptnml(0-2): [24, 384, 944, 404, 27], WL/DD Ratio: 0.47
sprt_equal_2t-1  | LLR: 2.90 (100.2%) (-2.25, 2.89) [-10.00, 0.00]
sprt_equal_2t-1  | --------------------------------------------------
```

```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 1.40 +/- 5.38, nElo: 2.58 +/- 9.92
sprt_equal-1  | LOS: 69.52 %, DrawRatio: 52.40 %, PairsRatio: 1.04
sprt_equal-1  | Games: 4710, Wins: 1025, Losses: 1006, Draws: 2679, Points: 2364.5 (50.20 %)
sprt_equal-1  | Ptnml(0-2): [46, 503, 1234, 530, 42], WL/DD Ratio: 0.50
sprt_equal-1  | LLR: 2.96 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```