### PR TITLE
Revert "🐛 FIX: Use Acquire/Release instead of Relaxed for AtomicPtr"

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -106,7 +106,7 @@ impl PositionNode {
 
     pub fn clear_children_links(&self) {
         for h in self.hots() {
-            h.child.store(null_mut(), Ordering::Release);
+            h.child.store(null_mut(), Ordering::Relaxed);
         }
     }
 
@@ -178,7 +178,7 @@ impl MoveEdge {
     }
 
     pub fn child(&self) -> Option<&PositionNode> {
-        let child = self.child.load(Ordering::Acquire).cast_const();
+        let child = self.child.load(Ordering::Relaxed).cast_const();
         if child.is_null() {
             None
         } else {
@@ -186,15 +186,16 @@ impl MoveEdge {
         }
     }
 
-    pub fn set_or_get_child<'a>(&'a self, new_child: &'a PositionNode) -> &'a PositionNode {
+    // Returns None if the child was set, or Some(child) if it was already set.
+    pub fn set_or_get_child<'a>(&'a self, new_child: &'a PositionNode) -> Option<&'a PositionNode> {
         match self.child.compare_exchange(
             null_mut(),
             ptr::from_ref(new_child).cast_mut(),
-            Ordering::Release,
-            Ordering::Acquire,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
         ) {
-            Ok(_) => new_child,
-            Err(existing) => unsafe { &*existing },
+            Ok(_) => None,
+            Err(existing) => unsafe { Some(&*existing) },
         }
     }
 }
@@ -442,7 +443,7 @@ impl SearchTree {
 
         // Lookup to see if we already have this position in the ttable
         if let Some(node) = self.ttable.lookup(state) {
-            return Ok(choice.set_or_get_child(node));
+            return Ok(choice.set_or_get_child(node).unwrap_or(node));
         }
 
         // Create the child
@@ -455,15 +456,11 @@ impl SearchTree {
         // Copy any history
         self.ttable.lookup_into(state, created);
 
-        match choice.child.compare_exchange(
-            null_mut(),
-            ptr::from_ref(created).cast_mut(),
-            Ordering::Release,
-            Ordering::Relaxed,
-        ) {
-            Ok(_) => Ok(self.ttable.insert(state, created)),
-            Err(existing) => unsafe { Ok(&*existing) },
-        }
+        // Insert the child into the ttable
+        let inserted = self.ttable.insert(state, created);
+        let inserted_ptr = ptr::from_ref(inserted).cast_mut();
+        choice.child.store(inserted_ptr, Ordering::Relaxed);
+        Ok(inserted)
     }
 
     fn finish_playout(path: &[&MoveEdge], evaln: i64) {

--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -147,7 +147,7 @@ impl LRTable {
     }
 
     pub fn is_left_current(&self) -> bool {
-        self.is_left_current.load(Ordering::Acquire)
+        self.is_left_current.load(Ordering::Relaxed)
     }
 
     pub fn generation(&self) -> u64 {
@@ -172,7 +172,10 @@ impl LRTable {
 
     fn flip_tables(&self) {
         self.previous_table().clear();
-        self.is_left_current.fetch_not(Ordering::Release);
+        self.is_left_current.store(
+            !self.is_left_current.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
         self.generation.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -244,7 +247,7 @@ impl<'a> LRAllocator<'a> {
     }
 
     fn is_left_current(&self) -> bool {
-        self.is_left_current.load(Ordering::Acquire)
+        self.is_left_current.load(Ordering::Relaxed)
     }
 
     pub fn alloc_node(


### PR DESCRIPTION
Reverts princesslana/princhess#392

Kills performance at 32 threads