### PR TITLE
📦 NEW: Hidden layer 256->320

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -13,7 +13,7 @@ use crate::nets::{q_i16, q_i32, save_to_bin, screlu, Accumulator, SCReLU};
 use crate::state::{self, State};
 
 const INPUT_SIZE: usize = state::VALUE_NUMBER_FEATURES;
-const HIDDEN_SIZE: usize = 256;
+const HIDDEN_SIZE: usize = 320;
 const OUTPUT_SIZE: usize = 1;
 
 const QA: i32 = 256;


### PR DESCRIPTION
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain-1  | Elo: 10.98 +/- 7.94, nElo: 18.28 +/- 13.21
sprt_gain-1  | LOS: 99.67 %, DrawRatio: 46.43 %, PairsRatio: 1.20
sprt_gain-1  | Games: 2658, Wins: 686, Losses: 602, Draws: 1370, Points: 1371.0 (51.58 %)
sprt_gain-1  | Ptnml(0-2): [33, 290, 617, 338, 51], WL/DD Ratio: 0.66
sprt_gain-1  | LLR: 2.92 (-2.25, 2.89) [0.00, 10.00]
sprt_gain-1  | --------------------------------------------------
```