### PR TITLE
📦 NEW: New net 800m positions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - ./builds/princhess-main:/engines/princhess-main
       - ./syzygy:/syzygy:ro
 
-  sprt_gain_5k:
+  sprt_gain_25k:
     build:
       context: .
       dockerfile: bin/Dockerfile.fastchess
@@ -64,7 +64,7 @@ services:
       -engine cmd=/engines/princhess name=princhess
       -engine cmd=/engines/princhess-main name=princhess-main
 
-      -each proto=uci tc=inf nodes=5000
+      -each proto=uci tc=inf nodes=25000
             option.SyzygyPath=/syzygy option.Hash=128 option.Threads=1
       -sprt elo0=0 elo1=10 alpha=0.05 beta=0.1 model=normalized
       -openings file=/books/UHO_Lichess_4852_v1.epd format=epd order=random


### PR DESCRIPTION
```
sprt_gain-1  | --------------------------------------------------
sprt_gain-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain-1  | Elo: 6.86 +/- 5.53, nElo: 11.49 +/- 9.25
sprt_gain-1  | LOS: 99.25 %, DrawRatio: 45.57 %, PairsRatio: 1.16
sprt_gain-1  | Games: 5420, Wins: 1345, Losses: 1238, Draws: 2837, Points: 2763.5 (50.99 %)
sprt_gain-1  | Ptnml(0-2): [78, 605, 1235, 716, 76], WL/DD Ratio: 0.63
sprt_gain-1  | LLR: 2.91 (-2.25, 2.89) [0.00, 10.00]
sprt_gain-1  | --------------------------------------------------
```