### PR TITLE
📦 NEW: Tidy up atomic usage in transposition table

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,6 +177,30 @@ services:
       - ./builds/princhess-main:/engines/princhess-main
       - ./syzygy:/syzygy:ro
       - ./pgn:/pgn
+    environment:
+      RUST_BACKTRACE: 1
+
+  debug_6t:
+    build:
+      context: .
+      dockerfile: bin/Dockerfile.fastchess
+    command:
+      -engine cmd=/engines/princhess name=princhess
+      -engine cmd=/engines/princhess-main name=princhess-main
+
+      -each proto=uci tc=8+0.08
+            option.SyzygyPath=/syzygy option.Hash=256 option.Threads=6
+      -openings file=/books/UHO_Lichess_4852_v1.epd format=epd order=random
+      -rounds 50
+      -log file=pgn/debug.log engine=true
+      -pgnout /pgn/debug.pgn
+    volumes:
+      - ./target/release/princhess:/engines/princhess
+      - ./builds/princhess-main:/engines/princhess-main
+      - ./syzygy:/syzygy:ro
+      - ./pgn:/pgn
+    environment:
+      RUST_BACKTRACE: 1
 
   tune:
     build:

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -308,15 +308,8 @@ impl SearchTree {
         let mut node = &self.root_node;
         let mut path: ArrayVec<&MoveEdge, MAX_PLAYOUT_LENGTH> = ArrayVec::new();
         let mut evaln = 0;
-        let generation = self.ttable.generation();
 
         loop {
-            self.ttable.wait_if_flipping();
-
-            if self.ttable.generation() != generation {
-                return true;
-            }
-
             if node.is_terminal() || node.hots().is_empty() {
                 break;
             }


### PR DESCRIPTION
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 3.00 +/- 6.33, nElo: 5.57 +/- 11.75
sprt_equal-1  | LOS: 82.36 %, DrawRatio: 52.50 %, PairsRatio: 1.07
sprt_equal-1  | Games: 3360, Wins: 737, Losses: 708, Draws: 1915, Points: 1694.5 (50.43 %)
sprt_equal-1  | Ptnml(0-2): [28, 358, 882, 381, 31], WL/DD Ratio: 0.50
sprt_equal-1  | LLR: 2.94 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------

sprt_equal_2t-1  | --------------------------------------------------
sprt_equal_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_equal_2t-1  | Elo: 2.49 +/- 5.90, nElo: 4.77 +/- 11.31
sprt_equal_2t-1  | LOS: 79.60 %, DrawRatio: 52.62 %, PairsRatio: 1.04
sprt_equal_2t-1  | Games: 3626, Wins: 772, Losses: 746, Draws: 2108, Points: 1826.0 (50.36 %)
sprt_equal_2t-1  | Ptnml(0-2): [17, 404, 954, 412, 26], WL/DD Ratio: 0.48
sprt_equal_2t-1  | LLR: 2.93 (101.5%) (-2.25, 2.89) [-10.00, 0.00]
sprt_equal_2t-1  | --------------------------------------------------
```