### PR TITLE
👌 IMP: Update Rust Docker base image to 1.87-bookworm

### DIFF
--- a/bin/Dockerfile.lichess
+++ b/bin/Dockerfile.lichess
@@ -1,4 +1,4 @@
-FROM rust:1.84-bookworm AS build
+FROM rust:1.87-bookworm AS build
 
 RUN apt-get update && apt-get install -y clang libclang-dev
 

--- a/bin/Dockerfile.lichess.policy
+++ b/bin/Dockerfile.lichess.policy
@@ -1,4 +1,4 @@
-FROM rust:1.84-bookworm AS build
+FROM rust:1.87-bookworm AS build
 
 RUN apt-get update && apt-get install -y clang libclang-dev
 


### PR DESCRIPTION
I've updated the FROM instruction in the following Dockerfiles to use rust:1.87-bookworm:
- bin/Dockerfile.lichess
- bin/Dockerfile.lichess.policy

This change ensures your project uses a more recent version of Rust for its Docker builds.