### PR TITLE
👌 IMP: Borrow transposition table in SearchTree

### DIFF
--- a/src/bin/data-gen.rs
+++ b/src/bin/data-gen.rs
@@ -212,7 +212,7 @@ fn run_game(stats: &Stats, positions: &mut Vec<TrainingPosition>, rng: &mut Rng)
 
     while let Some(mut state) = variations.pop() {
         let mut game_stats = GameStats::zero();
-        let mut table = LRTable::empty(HASH_SIZE_MB);
+        let table = LRTable::empty(HASH_SIZE_MB);
 
         if !state.is_available_move() {
             continue;
@@ -232,7 +232,7 @@ fn run_game(stats: &Stats, positions: &mut Vec<TrainingPosition>, rng: &mut Rng)
         let mut game_positions = Vec::with_capacity(256);
 
         let result = loop {
-            let search = Search::new(state.clone(), table, search_options);
+            let search = Search::new(state.clone(), &table, search_options);
             let legal_moves = search.root_node().hots().len();
 
             if legal_moves > 1 {
@@ -308,8 +308,6 @@ fn run_game(stats: &Stats, positions: &mut Vec<TrainingPosition>, rng: &mut Rng)
                 game_positions.clear();
                 break GameResult::Aborted;
             }
-
-            table = search.table();
         };
 
         let mut blunder = false;

--- a/src/search.rs
+++ b/src/search.rs
@@ -92,7 +92,7 @@ pub struct ThreadData<'a> {
 }
 
 impl<'a> ThreadData<'a> {
-    fn create(tree: &'a SearchTree) -> Self {
+    fn create(tree: &'a SearchTree<'a>) -> Self {
         Self {
             allocator: tree.allocator(),
             playouts: 0,
@@ -101,27 +101,18 @@ impl<'a> ThreadData<'a> {
 }
 
 #[must_use]
-pub struct Search {
-    search_tree: SearchTree,
+pub struct Search<'a> {
+    search_tree: SearchTree<'a>,
     search_options: SearchOptions,
 }
 
-impl Search {
-    pub fn new(state: State, table: LRTable, search_options: SearchOptions) -> Self {
+impl<'a> Search<'a> {
+    pub fn new(state: State, table: &'a LRTable, search_options: SearchOptions) -> Self {
         let search_tree = SearchTree::new(state, table, search_options);
         Self {
             search_tree,
             search_options,
         }
-    }
-
-    pub fn with_empty_table(state: State, search_options: SearchOptions) -> Self {
-        let table = LRTable::empty(search_options.hash_size_mb);
-        Self::new(state, table, search_options)
-    }
-
-    pub fn table(self) -> LRTable {
-        self.search_tree.table()
     }
 
     pub fn root_node(&self) -> &PositionNode {

--- a/src/train/data.rs
+++ b/src/train/data.rs
@@ -107,7 +107,7 @@ impl TrainingPosition {
     }
 }
 
-impl From<&SearchTree> for TrainingPosition {
+impl From<&SearchTree<'_>> for TrainingPosition {
     fn from(tree: &SearchTree) -> Self {
         let board = tree.root_state().board();
 

--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -122,7 +122,11 @@ impl LRTable {
     }
 
     pub fn full(&self) -> usize {
-        self.tables.iter().map(TranspositionTable::full).sum::<usize>() / self.tables.len()
+        self.tables
+            .iter()
+            .map(TranspositionTable::full)
+            .sum::<usize>()
+            / self.tables.len()
     }
 
     pub fn capacity_remaining(&self) -> usize {
@@ -196,18 +200,13 @@ pub struct LRAllocator<'a> {
 }
 
 impl<'a> LRAllocator<'a> {
-    pub fn from_arenas(
-        current: Arc<AtomicBool>,
-        left: &'a Arena,
-        right: &'a Arena,
-    ) -> Self {
+    pub fn from_arenas(current: Arc<AtomicBool>, left: &'a Arena, right: &'a Arena) -> Self {
         Self {
             allocators: [left.invalid_allocator(), right.invalid_allocator()],
             current,
         }
     }
     pub fn alloc_node(
-
         &self,
         edges: usize,
     ) -> Result<(&'a mut PositionNode, &'a mut [MoveEdge]), ArenaError> {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,3 +1,4 @@
+use crate::transposition_table::LRTable;
 use scoped_threadpool::Pool;
 use std::io::stdin;
 use std::str::SplitWhitespace;
@@ -17,7 +18,8 @@ const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 pub fn main() {
     let mut uci_options = UciOptionMap::default();
     let mut search_options = SearchOptions::from(&uci_options);
-    let mut search = Search::with_empty_table(State::default(), search_options);
+    let mut table = LRTable::empty(search_options.hash_size_mb);
+    let mut search = Search::new(State::default(), &table, search_options);
     let mut search_threads = Pool::new(1);
 
     let mut next_line: Option<String> = None;
@@ -36,34 +38,40 @@ pub fn main() {
                 "isready" => println!("readyok"),
                 "setoption" => {
                     if let Some((name, value)) = parse_set_option(tokens) {
+                        let root_state = search.root_state().clone();
+
                         uci_options.set(&name, &value);
-
-                        if name.to_lowercase().as_str() == "syzygypath" {
-                            set_tablebase_directory(&value);
-                        }
-
                         search_options = SearchOptions::from(&uci_options);
 
-                        search =
-                            Search::with_empty_table(search.root_state().clone(), search_options);
+                        match name.to_lowercase().as_str() {
+                            "threads" => {
+                                search_threads = Pool::new(search_options.threads);
+                            }
+                            "hash" => {
+                                table = LRTable::empty(search_options.hash_size_mb);
+                            }
+                            "syzygypath" => {
+                                set_tablebase_directory(&value);
+                            }
+                            _ => (),
+                        }
+
+                        search = Search::new(root_state, &table, search_options);
                     }
                 }
                 "ucinewgame" => {
-                    search = Search::with_empty_table(State::default(), search_options);
+                    table = LRTable::empty(search_options.hash_size_mb);
+                    search = Search::new(State::default(), &table, search_options);
                 }
                 "position" => {
                     if let Some(state) = State::from_tokens(tokens, search_options.is_chess960) {
-                        let prev_table = search.table();
-                        search = Search::new(state, prev_table, search_options);
+                        search = Search::new(state, &table, search_options);
                     } else {
                         println!("info string Couldn't parse '{line}' as position");
                     }
                 }
                 "quit" => return,
                 "go" => {
-                    if search_threads.thread_count() != search_options.threads {
-                        search_threads = Pool::new(search_options.threads);
-                    }
                     search.go(&mut search_threads, tokens, &mut next_line);
                 }
                 "movelist" => search.print_move_list(),


### PR DESCRIPTION
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 2.57 +/- 6.47, nElo: 4.95 +/- 12.47
sprt_equal-1  | LOS: 78.14 %, DrawRatio: 55.84 %, PairsRatio: 1.06
sprt_equal-1  | Games: 2980, Wins: 607, Losses: 585, Draws: 1788, Points: 1501.0 (50.37 %)
sprt_equal-1  | Ptnml(0-2): [23, 296, 832, 314, 25], WL/DD Ratio: 0.41
sprt_equal-1  | LLR: 2.45 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```

Failing on 2t
```
sprt_equal_2t-1  | --------------------------------------------------
sprt_equal_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_equal_2t-1  | Elo: -4.30 +/- 4.85, nElo: -8.19 +/- 9.25
sprt_equal_2t-1  | LOS: 4.13 %, DrawRatio: 52.84 %, PairsRatio: 0.91
sprt_equal_2t-1  | Games: 5420, Wins: 1097, Losses: 1164, Draws: 3159, Points: 2676.5 (49.38 %)
sprt_equal_2t-1  | Ptnml(0-2): [38, 632, 1432, 575, 33], WL/DD Ratio: 0.47
sprt_equal_2t-1  | LLR: -1.43 (-63.6%) (-2.25, 2.89) [-10.00, 0.00]
sprt_equal_2t-1  | --------------------------------------------------
```