### PR TITLE
👌 IMP: Add generational ArenaRef for TT invalidation

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -158,7 +158,7 @@ impl<'a> Allocator<'a> {
     pub fn alloc_one<T>(&self) -> Result<ArenaRef<T>, Error> {
         assert!(ALIGN % mem::align_of::<T>() == 0);
         let x = mem::size_of::<T>();
-        let x = x + ((!x + 1) % ALIGN);
+        let x = (x + ALIGN - 1) & !(ALIGN - 1);
         let x = self.get_memory(x)?;
         let current_generation = self.arena.generation.load(Ordering::Acquire);
         Ok(ArenaRef {
@@ -170,7 +170,7 @@ impl<'a> Allocator<'a> {
     pub fn alloc_slice<T>(&self, sz: usize) -> Result<ArenaRef<[T]>, Error> {
         assert!(ALIGN % mem::align_of::<T>() == 0);
         let x = mem::size_of::<T>();
-        let x = x + ((!x + 1) % ALIGN);
+        let x = (x + ALIGN - 1) & !(ALIGN - 1);
         let x = self.get_memory(x * sz)?;
         let current_generation = self.arena.generation.load(Ordering::Acquire);
         Ok(ArenaRef {
@@ -201,6 +201,16 @@ impl<T: ?Sized> ArenaRef<T> {
     #[must_use]
     pub fn generation(&self) -> u64 {
         self.generation
+    }
+
+    #[must_use]
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr.as_ptr()
     }
 }
 

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -215,7 +215,6 @@ where
     let (mut node_arena_ref, mut hots_arena_ref) = alloc(move_eval.len())?;
 
     let node_ptr = node_arena_ref.as_mut_ptr();
-    // Get a raw pointer to the first element of the MoveEdge slice
     let hots_base_ptr: *mut MoveEdge = hots_arena_ref.as_mut_ptr().cast::<MoveEdge>();
 
     #[allow(clippy::cast_sign_loss)]

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -215,15 +215,16 @@ where
     let (mut node_arena_ref, mut hots_arena_ref) = alloc(move_eval.len())?;
 
     let node_ptr = node_arena_ref.as_mut_ptr();
-    let hots_ptr = hots_arena_ref.as_mut_ptr();
+    // Get a raw pointer to the first element of the MoveEdge slice
+    let hots_base_ptr: *mut MoveEdge = hots_arena_ref.as_mut_ptr().cast::<MoveEdge>();
 
     #[allow(clippy::cast_sign_loss)]
     for (i, &mov) in moves.iter().enumerate() {
         let policy_val = (move_eval[i] * SCALE) as u16;
-        // SAFETY: `hots_ptr` points to valid, uninitialized memory for `move_eval.len()` MoveEdge elements.
+        // SAFETY: `hots_base_ptr.add(i)` points to valid, uninitialized memory for a single MoveEdge.
         // We are writing each element exactly once.
         unsafe {
-            std::ptr::write(hots_ptr.add(i), MoveEdge::new(policy_val, mov));
+            std::ptr::write(hots_base_ptr.add(i), MoveEdge::new(policy_val, mov));
         }
     }
 


### PR DESCRIPTION
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 3.63 +/- 6.61, nElo: 6.88 +/- 12.51
sprt_equal-1  | LOS: 85.96 %, DrawRatio: 52.50 %, PairsRatio: 1.09
sprt_equal-1  | Games: 2964, Wins: 656, Losses: 625, Draws: 1683, Points: 1497.5 (50.52 %)
sprt_equal-1  | Ptnml(0-2): [20, 317, 778, 346, 21], WL/DD Ratio: 0.53
sprt_equal-1  | LLR: 2.91 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------

sprt_equal_2t-1  | --------------------------------------------------
sprt_equal_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_equal_2t-1  | Elo: -0.05 +/- 4.26, nElo: -0.09 +/- 8.01
sprt_equal_2t-1  | LOS: 49.12 %, DrawRatio: 51.43 %, PairsRatio: 0.98
sprt_equal_2t-1  | Games: 7222, Wins: 1542, Losses: 1543, Draws: 4137, Points: 3610.5 (49.99 %)
sprt_equal_2t-1  | Ptnml(0-2): [42, 842, 1857, 815, 55], WL/DD Ratio: 0.50
sprt_equal_2t-1  | LLR: 2.93 (101.5%) (-2.25, 2.89) [-10.00, 0.00]
sprt_equal_2t-1  | --------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced generation-tracking references for arena-allocated objects, providing safer and more robust handle management.
  - Added a method to retrieve the current generation counter for arenas.

- **Refactor**
  - Replaced raw mutable references with generation-aware arena references throughout node and edge management.
  - Updated public method signatures and struct fields to use the new arena reference type.
  - Enhanced transposition table logic to validate entries based on generation, improving consistency and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->