### PR TITLE
👌 IMP: switch arena to use atomic counters instead of mutex

### DIFF
--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -222,7 +222,7 @@ where
 
     // SAFETY: `node_uninit_ref` points to valid, uninitialized memory for a single PositionNode.
     // We are writing it exactly once.
-    let node_arena_ref = node_uninit_ref.write(PositionNode::new(&*hots_arena_ref, state_flag));
+    let node_arena_ref = node_uninit_ref.write(PositionNode::new(&hots_arena_ref, state_flag));
 
     Ok(node_arena_ref)
 }


### PR DESCRIPTION
```
sprt_equal_2t-1  | --------------------------------------------------
sprt_equal_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_equal_2t-1  | Elo: 7.01 +/- 8.24, nElo: 13.17 +/- 15.48
sprt_equal_2t-1  | LOS: 95.22 %, DrawRatio: 51.91 %, PairsRatio: 1.13
sprt_equal_2t-1  | Games: 1934, Wins: 430, Losses: 391, Draws: 1113, Points: 986.5 (51.01 %)
sprt_equal_2t-1  | Ptnml(0-2): [9, 209, 502, 228, 19], WL/DD Ratio: 0.49
sprt_equal_2t-1  | LLR: 2.91 (100.7%) (-2.25, 2.89) [-10.00, 0.00]
sprt_equal_2t-1  | --------------------------------------------------

sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 2.55 +/- 5.90, nElo: 4.96 +/- 11.45
sprt_equal-1  | LOS: 80.18 %, DrawRatio: 54.64 %, PairsRatio: 1.05
sprt_equal-1  | Games: 3536, Wins: 748, Losses: 722, Draws: 2066, Points: 1781.0 (50.37 %)
sprt_equal-1  | Ptnml(0-2): [20, 371, 966, 385, 26], WL/DD Ratio: 0.47
sprt_equal-1  | LLR: 2.91 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance and concurrency in chunk allocation by replacing mutex-based synchronization with atomic operations and unsafe interior mutability.
  - Simplified internal handling of arena references for node creation.

No changes to user-facing features or documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->