### PR TITLE
📦 NEW: add graph module for search tree nodes and edges

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -7,7 +7,7 @@
     and DRY (Don't Repeat Yourself) 
   * Code Comments are:
     * Ideally avoided, in preference of self-documenting code
-    * Used to explain why something is done, not what is done
+    * Used to explain why the code is as it is, not what it does
 
 ## Commit Messages
 

--- a/src/bin/data-gen.rs
+++ b/src/bin/data-gen.rs
@@ -233,7 +233,7 @@ fn run_game(stats: &Stats, positions: &mut Vec<TrainingPosition>, rng: &mut Rng)
 
         let result = loop {
             search.set_root_state(state.clone());
-            let legal_moves = search.root_node().hots().len();
+            let legal_moves = search.root_node().edges().len();
 
             if legal_moves > 1 {
                 let visits = search.root_node().visits();
@@ -243,12 +243,12 @@ fn run_game(stats: &Stats, positions: &mut Vec<TrainingPosition>, rng: &mut Rng)
             let best_move = search.best_move();
 
             if variations_count < MAX_VARIATIONS {
-                let varation = search.most_visited_move();
+                let variation = search.most_visited_move();
 
-                if varation != best_move && state.phase() > 18 {
+                if variation != best_move && state.phase() > 18 {
                     game_stats.variations += 1;
                     let mut state = state.clone();
-                    state.make_move(varation);
+                    state.make_move(variation);
                     variations.push(state);
                     variations_count += 1;
                 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,270 @@
+use std::mem;
+use std::ops::Deref;
+use std::ptr::{self, null_mut, NonNull};
+use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicU32, Ordering};
+use std::sync::LazyLock;
+
+use crate::arena::{ArenaRef, Error as ArenaError};
+use crate::chess;
+use crate::evaluation::{self, Flag};
+use crate::search::SCALE;
+use crate::state::State;
+use crate::transposition_table::AllocNodeResult;
+
+// Removed MAX_PLAYOUT_LENGTH and PV_EVAL_MIN_DEPTH from here
+
+pub struct MoveEdge {
+    sum_evaluations: AtomicI64,
+    visits: AtomicU32,
+    policy: u16,
+    mov: chess::Move,
+    child: AtomicPtr<PositionNode>,
+}
+
+#[derive(Clone, Copy)]
+pub struct Edges(NonNull<[MoveEdge]>);
+
+impl Deref for Edges {
+    type Target = [MoveEdge];
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: The NonNull guarantees the pointer is valid and non-null.
+        // The lifetime 'static is appropriate as the underlying data is either
+        // from a static empty slice or from the Arena, which outlives the Edges.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+// SAFETY: Edges wraps NonNull<[MoveEdge]>.
+// MoveEdge is Send and Sync (due to Atomic types and chess::Move).
+// The pointer itself is just a reference, not owning the data,
+// and the underlying data (from static EMPTY_EDGES or Arena) is safely managed
+// and accessible across threads.
+unsafe impl Send for Edges {}
+unsafe impl Sync for Edges {}
+
+#[derive(Clone)]
+pub struct PositionNode {
+    edges: Edges,
+    flag: Flag,
+    generation: u32,
+}
+
+pub struct Reward {
+    pub average: i32,
+    pub visits: u32,
+}
+
+impl Reward {
+    pub const ZERO: Self = Self {
+        average: -SCALE as i32,
+        visits: 0,
+    };
+}
+
+unsafe impl Sync for PositionNode {}
+
+// Static empty slice for nodes with no moves
+static EMPTY_EDGES: LazyLock<Edges> = LazyLock::new(|| {
+    let s: &'static [MoveEdge] = &[];
+    // SAFETY: A static empty slice is guaranteed to be non-null.
+    // Using ptr::from_ref and cast_mut to satisfy clippy warnings.
+    // The result of cast_mut() needs to be wrapped in NonNull::new_unchecked().
+    Edges(unsafe { NonNull::new_unchecked(ptr::from_ref(s).cast_mut()) })
+});
+
+// Macro to define static PositionNode instances
+macro_rules! define_static_node {
+    ($name:ident, $flag:expr) => {
+        pub static $name: LazyLock<PositionNode> =
+            LazyLock::new(|| PositionNode::new_static($flag));
+    };
+}
+
+// These static nodes, created via `PositionNode::new_static`, are not allocated in an Arena,
+// so their generation is 0 (invalid). This is fine as they are never looked up in the TT or cleared.
+define_static_node!(WIN_NODE, Flag::TerminalWin);
+define_static_node!(DRAW_NODE, Flag::TerminalDraw);
+define_static_node!(LOSS_NODE, Flag::TerminalLoss);
+
+define_static_node!(TABLEBASE_WIN_NODE, Flag::TablebaseWin);
+define_static_node!(TABLEBASE_DRAW_NODE, Flag::TablebaseDraw);
+define_static_node!(TABLEBASE_LOSS_NODE, Flag::TablebaseLoss);
+
+define_static_node!(UNEXPANDED_NODE, Flag::Standard);
+
+impl PositionNode {
+    fn new(edges: Edges, flag: Flag, generation: u32) -> Self {
+        Self {
+            edges,
+            flag,
+            generation,
+        }
+    }
+
+    pub fn new_static(flag: Flag) -> Self {
+        Self {
+            edges: *EMPTY_EDGES,
+            flag,
+            generation: 0,
+        }
+    }
+
+    pub fn flag(&self) -> Flag {
+        self.flag
+    }
+
+    pub fn set_flag(&mut self, flag: Flag) {
+        self.flag = flag;
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.flag.is_terminal()
+    }
+
+    pub fn is_tablebase(&self) -> bool {
+        self.flag.is_tablebase()
+    }
+
+    pub fn edges(&self) -> &[MoveEdge] {
+        &self.edges
+    }
+
+    pub fn visits(&self) -> u64 {
+        self.edges().iter().map(|x| u64::from(x.visits())).sum()
+    }
+
+    pub fn clear_children_links(&self) {
+        for h in self.edges() {
+            h.child.store(null_mut(), Ordering::Relaxed);
+        }
+    }
+
+    pub fn select_child_by_rewards(&self) -> &MoveEdge {
+        self.edges()
+            .iter()
+            .max_by_key(|x| x.reward().average)
+            .unwrap()
+    }
+
+    pub fn select_child_by_visits(&self) -> &MoveEdge {
+        self.edges().iter().max_by_key(|x| x.visits()).unwrap()
+    }
+
+    pub fn generation(&self) -> u32 {
+        self.generation
+    }
+}
+
+impl MoveEdge {
+    fn new(policy: u16, mov: chess::Move) -> Self {
+        Self {
+            policy,
+            sum_evaluations: AtomicI64::default(),
+            visits: AtomicU32::default(),
+            mov,
+            child: AtomicPtr::default(),
+        }
+    }
+
+    pub fn get_move(&self) -> &chess::Move {
+        &self.mov
+    }
+
+    pub fn visits(&self) -> u32 {
+        self.visits.load(Ordering::Relaxed)
+    }
+
+    pub fn policy(&self) -> u16 {
+        self.policy
+    }
+
+    pub fn reward(&self) -> Reward {
+        let visits = self.visits.load(Ordering::Relaxed);
+
+        if visits == 0 {
+            return Reward::ZERO;
+        }
+
+        let sum = self.sum_evaluations.load(Ordering::Relaxed);
+
+        Reward {
+            average: (sum / i64::from(visits)) as i32,
+            visits,
+        }
+    }
+
+    pub fn down(&self) {
+        self.visits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn up(&self, evaln: i64) {
+        self.sum_evaluations.fetch_add(evaln, Ordering::Relaxed);
+    }
+
+    pub fn replace(&self, other: &MoveEdge) {
+        self.visits
+            .store(other.visits.load(Ordering::Relaxed), Ordering::Relaxed);
+        self.sum_evaluations.store(
+            other.sum_evaluations.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+    }
+
+    pub fn child(&self) -> Option<&PositionNode> {
+        let child = self.child.load(Ordering::Relaxed).cast_const();
+        if child.is_null() {
+            None
+        } else {
+            unsafe { Some(&*child) }
+        }
+    }
+
+    pub fn set_child_ptr(&self, node: &PositionNode) {
+        self.child
+            .store(ptr::from_ref(node).cast_mut(), Ordering::Relaxed);
+    }
+}
+
+pub fn create_node<F>(
+    state: &State,
+    alloc: F,
+    policy_t: f32,
+) -> Result<ArenaRef<PositionNode>, ArenaError>
+where
+    F: FnOnce(usize) -> AllocNodeResult,
+{
+    let moves = state.available_moves();
+
+    let state_flag = evaluation::evaluate_state_flag(state, !moves.is_empty());
+    let move_eval = evaluation::policy(state, &moves, policy_t);
+
+    let (node_uninit_ref, edges_uninit_ref) = alloc(move_eval.len())?;
+
+    #[allow(clippy::cast_sign_loss)]
+    let edges_arena_ref = edges_uninit_ref.init_each(|i| {
+        let policy_val = (move_eval[i] * SCALE) as u16;
+        MoveEdge::new(policy_val, moves[i])
+    });
+
+    // Capture the generation before `node_uninit_ref` is moved by `write`.
+    let node_generation = node_uninit_ref.generation();
+
+    // SAFETY: `node_uninit_ref` points to valid, uninitialized memory for a single PositionNode.
+    // We are writing it exactly once.
+    let node_arena_ref = node_uninit_ref.write(PositionNode::new(
+        Edges(edges_arena_ref.into_non_null()),
+        state_flag,
+        node_generation,
+    ));
+
+    Ok(node_arena_ref)
+}
+
+pub fn print_size_list() {
+    println!(
+        "info string PositionNode {} MoveEdge {}",
+        mem::size_of::<PositionNode>(),
+        mem::size_of::<MoveEdge>(),
+    );
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -66,9 +66,7 @@ unsafe impl Sync for PositionNode {}
 static EMPTY_EDGES: LazyLock<Edges> = LazyLock::new(|| {
     let s: &'static [MoveEdge] = &[];
     // SAFETY: A static empty slice is guaranteed to be non-null.
-    // Using ptr::from_ref and cast_mut to satisfy clippy warnings.
-    // The result of cast_mut() needs to be wrapped in NonNull::new_unchecked().
-    Edges(unsafe { NonNull::new_unchecked(ptr::from_ref(s).cast_mut()) })
+    Edges(NonNull::from(s))
 });
 
 // Macro to define static PositionNode instances

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 mod arena;
+mod graph;
 mod mem;
 mod nets;
 mod search_tree;

--- a/src/search.rs
+++ b/src/search.rs
@@ -63,7 +63,7 @@ impl Search {
     }
 
     pub fn tree(&self) -> &SearchTree {
-        &self.search_tree // Fixed: Return reference to the field directly
+        &self.search_tree
     }
 
     pub fn table_full(&self) -> usize {
@@ -142,7 +142,7 @@ impl Search {
                 self.search_tree
                     .print_info(&time_management, self.ttable.full());
                 stop_signal.store(true, Ordering::Relaxed);
-                println!("bestmove {}", self.to_uci(self.best_move()),);
+                println!("bestmove {}", self.to_uci(self.best_move()));
             });
 
             for _ in 0..(thread_count - 1) {
@@ -199,7 +199,7 @@ impl Search {
         let root_node = self.search_tree.root_node();
         let root_state = self.search_tree.root_state();
 
-        let root_moves = root_node.edges(); // Changed from hots()
+        let root_moves = root_node.edges();
 
         let state_moves = root_state.available_moves();
         let state_moves_eval = evaluation::policy(
@@ -246,6 +246,7 @@ impl Search {
             .search_tree
             .root_node()
             .select_child_by_visits()
+            .expect("Root node must have moves to determine most visited move")
             .get_move()
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,9 +3,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::chess::Move;
 use crate::evaluation;
+use crate::graph::{MoveEdge, PositionNode};
 use crate::math::Rng;
 use crate::options::SearchOptions;
-use crate::search_tree::{MoveEdge, PositionNode, SearchTree};
+use crate::search_tree::SearchTree;
 use crate::state::State;
 use crate::tablebase;
 use crate::time_management::TimeManagement;
@@ -62,7 +63,7 @@ impl Search {
     }
 
     pub fn tree(&self) -> &SearchTree {
-        &self.search_tree
+        &self.search_tree // Fixed: Return reference to the field directly
     }
 
     pub fn table_full(&self) -> usize {
@@ -198,7 +199,7 @@ impl Search {
         let root_node = self.search_tree.root_node();
         let root_state = self.search_tree.root_state();
 
-        let root_moves = root_node.hots();
+        let root_moves = root_node.edges(); // Changed from hots()
 
         let state_moves = root_state.available_moves();
         let state_moves_eval = evaluation::policy(

--- a/src/search_tree.rs
+++ b/src/search_tree.rs
@@ -280,7 +280,10 @@ impl SearchTree {
     }
 
     pub fn best_edge(&self) -> &MoveEdge {
-        self.sort_moves(self.root_node.edges()).into_iter().next().expect("Root node must have moves to determine best edge")
+        self.sort_moves(self.root_node.edges())
+            .into_iter()
+            .next()
+            .expect("Root node must have moves to determine best edge")
     }
 
     fn sort_moves<'b>(&self, children: &'b [MoveEdge]) -> Vec<&'b MoveEdge> {
@@ -312,7 +315,10 @@ impl SearchTree {
     fn soft_time_multiplier(&self, opts: &TimeManagementOptions) -> f32 {
         let mut m = 1.0;
 
-        let bm = self.root_node().select_child_by_rewards().expect("Root node must have moves during active search for time management");
+        let bm = self
+            .root_node()
+            .select_child_by_rewards()
+            .expect("Root node must have moves during active search for time management");
         let bm_reward = bm.reward();
 
         let bm_frac = bm_reward.visits as f32 / self.root_node().visits() as f32;

--- a/src/train/data.rs
+++ b/src/train/data.rs
@@ -151,9 +151,8 @@ impl From<&SearchTree> for TrainingPosition {
 
         evaluation_i64 = stm
             .fold(evaluation_i64, -evaluation_i64)
-            .clamp(-(SCALE as i64), SCALE as i64); // Clamping with i64 values
+            .clamp(-(SCALE as i64), SCALE as i64);
 
-        // Convert to i32, assuming it fits within the range as per your statement
         let evaluation = evaluation_i64 as i32;
 
         // zero'd to be filled in later

--- a/src/train/data.rs
+++ b/src/train/data.rs
@@ -24,6 +24,7 @@ pub struct TrainingPosition {
     visits: [u8; TrainingPosition::MAX_MOVES],
 }
 
+// Updated size check: 8 (occupied) + 16 (pieces) + 4 (evaluation) + 1 (result) + 1 (stm) + 108 (legal_moves) + 54 (visits) = 192
 const _SIZE_CHECK: () = assert!(mem::size_of::<TrainingPosition>() == 192);
 
 impl TrainingPosition {
@@ -146,12 +147,14 @@ impl From<&SearchTree> for TrainingPosition {
         }
 
         let pv = tree.best_edge();
-        let mut evaluation = pv.reward().average;
+        let mut evaluation_i64 = pv.reward().average;
 
-        // white relative evaluation
-        evaluation = stm
-            .fold(evaluation, -evaluation)
-            .clamp(-SCALE as i32, SCALE as i32);
+        evaluation_i64 = stm
+            .fold(evaluation_i64, -evaluation_i64)
+            .clamp(-(SCALE as i64), SCALE as i64); // Clamping with i64 values
+
+        // Convert to i32, assuming it fits within the range as per your statement
+        let evaluation = evaluation_i64 as i32;
 
         // zero'd to be filled in later
         let result = 0;

--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::arena::{Allocator, Arena, ArenaRef, Error as ArenaError};
-use crate::search_tree::{MoveEdge, PositionNode};
+use crate::graph::{MoveEdge, PositionNode};
 use crate::state::State;
 
 struct Entry {
@@ -105,8 +105,8 @@ impl TranspositionTable {
         if let Some(src) = self.lookup(state) {
             dest.set_flag(src.flag());
 
-            let lhs = dest.hots();
-            let rhs = src.hots();
+            let lhs = dest.edges();
+            let rhs = src.edges();
 
             for i in 0..lhs.len().min(rhs.len()) {
                 lhs[i].replace(&rhs[i]);

--- a/src/tree_policy.rs
+++ b/src/tree_policy.rs
@@ -1,9 +1,9 @@
 use fastapprox::faster;
 use std::f32;
 
+use crate::graph::MoveEdge;
 use crate::options::MctsOptions;
 use crate::search::SCALE;
-use crate::search_tree::MoveEdge;
 
 pub fn choose_child<'a>(moves: &'a [MoveEdge], fpu: i32, options: &MctsOptions) -> &'a MoveEdge {
     let total_visits = moves.iter().map(|v| u64::from(v.visits())).sum::<u64>() + 1;

--- a/src/tree_policy.rs
+++ b/src/tree_policy.rs
@@ -5,7 +5,7 @@ use crate::graph::MoveEdge;
 use crate::options::MctsOptions;
 use crate::search::SCALE;
 
-pub fn choose_child<'a>(moves: &'a [MoveEdge], fpu: i32, options: &MctsOptions) -> &'a MoveEdge {
+pub fn choose_child<'a>(moves: &'a [MoveEdge], fpu: i64, options: &MctsOptions) -> &'a MoveEdge {
     let total_visits = moves.iter().map(|v| u64::from(v.visits())).sum::<u64>() + 1;
 
     let explore_coef = (options.cpuct
@@ -19,11 +19,11 @@ pub fn choose_child<'a>(moves: &'a [MoveEdge], fpu: i32, options: &MctsOptions) 
         let reward = mov.reward();
         let policy_evaln = mov.policy();
 
-        let q = i64::from(if reward.visits > 0 {
+        let q = if reward.visits > 0 {
             reward.average
         } else {
             fpu
-        });
+        };
 
         let u = explore_coef * i64::from(policy_evaln)
             / ((i64::from(reward.visits) + 1) * SCALE as i64);

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -2,9 +2,9 @@ use scoped_threadpool::Pool;
 use std::io::stdin;
 use std::str::SplitWhitespace;
 
+use crate::graph::print_size_list;
 use crate::options::{SearchOptions, UciOption, UciOptionMap};
 use crate::search::Search;
-use crate::search_tree::print_size_list;
 use crate::state::State;
 use crate::tablebase::set_tablebase_directory;
 use crate::time_management::TimeManagement;


### PR DESCRIPTION
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 5.05 +/- 7.28, nElo: 9.64 +/- 13.88
sprt_equal-1  | LOS: 91.31 %, DrawRatio: 54.61 %, PairsRatio: 1.12
sprt_equal-1  | Games: 2406, Wins: 539, Losses: 504, Draws: 1363, Points: 1220.5 (50.73 %)
sprt_equal-1  | Ptnml(0-2): [18, 239, 657, 268, 21], WL/DD Ratio: 0.54
sprt_equal-1  | LLR: 2.91 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------

sprt_equal_2t-1  | --------------------------------------------------
sprt_equal_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_equal_2t-1  | Elo: 0.54 +/- 4.72, nElo: 1.01 +/- 8.92
sprt_equal_2t-1  | LOS: 58.80 %, DrawRatio: 50.45 %, PairsRatio: 1.00
sprt_equal_2t-1  | Games: 5832, Wins: 1263, Losses: 1254, Draws: 3315, Points: 2920.5 (50.08 %)
sprt_equal_2t-1  | Ptnml(0-2): [28, 694, 1471, 687, 36], WL/DD Ratio: 0.52
sprt_equal_2t-1  | LLR: 2.90 (100.4%) (-2.25, 2.89) [-10.00, 0.00]
sprt_equal_2t-1  | --------------------------------------------------

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new data structures for managing search graphs, including nodes and edges, enhancing the internal representation of game states.
	- Added a utility to display memory size information for core data structures.

- **Refactor**
	- Centralized node and edge logic into a dedicated module, improving code organization and maintainability.
	- Updated various components to use the new module for accessing and managing search graph data.

- **Bug Fixes**
	- Corrected variable naming inconsistencies and improved clarity in variable usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->