### PR TITLE
📦 NEW: Policy aux target

### DIFF
--- a/src/bin/train-policy.rs
+++ b/src/bin/train-policy.rs
@@ -19,7 +19,7 @@ const LR: f32 = 0.001;
 const LR_DROP_AT: f32 = 0.4;
 const LR_DROP_FACTOR: f32 = 0.5;
 
-const SOFT_TARGET_WEIGHT: f32 = 8.0;
+const SOFT_TARGET_WEIGHT: f32 = 0.1;
 const SOFT_TARGET_TEMPERATURE: f32 = 4.0;
 
 const _BUFFER_SIZE_CHECK: () = assert!(TrainingPosition::BUFFER_SIZE % BATCH_SIZE == 0);

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -108,7 +108,7 @@ fn run_policy_net(_state: &State, moves: &MoveList, _t: f32) -> Vec<f32> {
 
 #[cfg(feature = "policy-net")]
 fn run_policy_net(state: &State, moves: &MoveList, t: f32) -> Vec<f32> {
-    let mut evalns = Vec::with_capacity(moves.len());
+    let mut evalns = vec![0.0; moves.len()];
 
     if moves.is_empty() {
         return evalns;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -135,9 +135,9 @@ impl PolicyNetwork {
         &self,
         features: &SparseVector,
         move_idxes: I,
-        out: &mut Vec<f32>,
+        out: &mut [f32],
     ) {
-        for move_idx in move_idxes {
+        for (i, move_idx) in move_idxes.enumerate() {
             let from_piece_sq = move_idx.from_piece_sq_index();
 
             let to_piece_sq = move_idx.to_piece_sq_index();
@@ -148,9 +148,8 @@ impl PolicyNetwork {
             let from_piece_sq_logits = self.get_piece_sq(from_piece_sq).out(features);
             let to_piece_sq_logits = self.get_piece_sq(to_piece_sq).out(features);
 
-            out.push(
-                to_sq_logits.dot(&to_piece_sq_logits) - from_sq_logits.dot(&from_piece_sq_logits),
-            );
+            out[i] =
+                to_sq_logits.dot(&to_piece_sq_logits) - from_sq_logits.dot(&from_piece_sq_logits);
         }
     }
 
@@ -248,9 +247,9 @@ impl QuantizedPolicyNetwork {
         &self,
         features: &SparseVector,
         move_idxes: I,
-        out: &mut Vec<f32>,
+        out: &mut [f32],
     ) {
-        for move_idx in move_idxes {
+        for (i, move_idx) in move_idxes.enumerate() {
             let from_sq_idx = move_idx.from_sq().index();
             let to_sq_idx = move_idx.to_sq().index();
 
@@ -271,7 +270,7 @@ impl QuantizedPolicyNetwork {
                 self.piece_sq.set(to_piece_sq_idx, *f, &mut to_piece_sq);
             }
 
-            out.push(to_sq.dot_relu(&to_piece_sq) - from_sq.dot_relu(&from_piece_sq));
+            out[i] = to_sq.dot_relu(&to_piece_sq) - from_sq.dot_relu(&from_piece_sq);
         }
     }
 }


### PR DESCRIPTION
```
prt_gain_ltc-1  | --------------------------------------------------
sprt_gain_ltc-1  | Results of princhess vs princhess-main (40+0.4, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain_ltc-1  | Elo: 6.63 +/- 6.59, nElo: 12.42 +/- 12.35
sprt_gain_ltc-1  | LOS: 97.56 %, DrawRatio: 50.82 %, PairsRatio: 1.14
sprt_gain_ltc-1  | Games: 3042, Wins: 638, Losses: 580, Draws: 1824, Points: 1550.0 (50.95 %)
sprt_gain_ltc-1  | Ptnml(0-2): [16, 333, 773, 375, 24], WL/DD Ratio: 0.39
sprt_gain_ltc-1  | LLR: 1.87 (-1.50, 2.08) [0.00, 10.00]
sprt_gain_ltc-1  | --------------------------------------------------

sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 4.38 +/- 7.30, nElo: 7.76 +/- 12.93
sprt_equal-1  | LOS: 88.04 %, DrawRatio: 49.17 %, PairsRatio: 1.09
sprt_equal-1  | Games: 2774, Wins: 631, Losses: 596, Draws: 1547, Points: 1404.5 (50.63 %)
sprt_equal-1  | Ptnml(0-2): [28, 309, 682, 336, 32], WL/DD Ratio: 0.51
sprt_equal-1  | LLR: 2.92 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced policy network training with a secondary, softened target distribution to improve learning.
- **Improvements**
  - Training loss and accuracy calculations now blend primary and soft targets for more robust model updates.
  - Policy network output handling optimized for more efficient data processing.
  - Evaluation process updated to initialize move evaluations with zero values for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->