### PR TITLE
📦 NEW: migrate from scoped_threadpool to rayon for parallel search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,8 +309,8 @@ dependencies = [
  "goober",
  "memmap",
  "nohash-hasher",
+ "rayon",
  "scc",
- "scoped_threadpool",
 ]
 
 [[package]]
@@ -304,6 +329,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -362,12 +407,6 @@ checksum = "28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640"
 dependencies = [
  "sdd",
 ]
-
-[[package]]
-name = "scoped_threadpool"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "sdd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ goober = { git = "https://github.com/jw1912/goober/", rev = "32b9b52" }
 nohash-hasher = "=0.2.0"
 memmap = "=0.7.0"
 scc = "=2.3.0"
-scoped_threadpool = "=0.1.9"
+rayon = "1.10.0"
 
 [features]
 default = ["policy-net", "value-net", "fathom"]

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -91,7 +91,7 @@ impl Uci {
             self.options.set(&name, &value);
             self.search_options = SearchOptions::from(&self.options);
 
-            if name.to_lowercase().as_str() == "syzygypath" {
+            if name.eq_ignore_ascii_case("syzygypath") {
                 set_tablebase_directory(&value);
             }
 


### PR DESCRIPTION
```
sprt_equal_2t-1  | --------------------------------------------------
sprt_equal_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_equal_2t-1  | Elo: -0.58 +/- 3.83, nElo: -1.08 +/- 7.17
sprt_equal_2t-1  | LOS: 38.39 %, DrawRatio: 51.16 %, PairsRatio: 0.99
sprt_equal_2t-1  | Games: 9030, Wins: 1878, Losses: 1893, Draws: 5259, Points: 4507.5 (49.92 %)
sprt_equal_2t-1  | Ptnml(0-2): [64, 1045, 2310, 1034, 62], WL/DD Ratio: 0.45
sprt_equal_2t-1  | LLR: 2.93 (101.5%) (-2.25, 2.89) [-10.00, 0.00]
sprt_equal_2t-1  | --------------------------------------------------
```

```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: -0.35 +/- 3.93, nElo: -0.67 +/- 7.59
sprt_equal-1  | LOS: 43.18 %, DrawRatio: 53.75 %, PairsRatio: 0.98
sprt_equal-1  | Games: 8056, Wins: 1654, Losses: 1662, Draws: 4740, Points: 4024.0 (49.95 %)
sprt_equal-1  | Ptnml(0-2): [44, 898, 2165, 864, 57], WL/DD Ratio: 0.45
sprt_equal-1  | LLR: 2.89 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal parallel processing by switching to a new threading library, resulting in more efficient multi-threaded operations.
  - Streamlined command handling for better maintainability and reliability.
- **Chores**
  - Updated dependencies for improved performance and future compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->