### PR TITLE
Fix critical bugs in MCTS implementation

### DIFF
--- a/deps/fathom/src/tbprobe.c
+++ b/deps/fathom/src/tbprobe.c
@@ -2456,7 +2456,7 @@ void tb_expand_mate(Pos *pos, struct TbRootMove *move, Value moveScore, unsigned
   }
 
   // Now try to expand until the actual mate.
-  if (popcount(pos->white | pos->black) <= cardinalityDTM) {
+  if ((unsigned)popcount(pos->white | pos->black) <= cardinalityDTM) {
     while (v != -TB_VALUE_MATE && move->pvSize < TB_MAX_PLY) {
       v = v > 0 ? -v - 1 : -v + 1;
       wdl = -wdl;

--- a/src/nets.rs
+++ b/src/nets.rs
@@ -18,10 +18,10 @@ impl Activation for SCReLU {
     }
 
     fn derivative(x: f32) -> f32 {
-        if 0.0 < x && x < 1.0 {
-            2.0 * x.sqrt()
-        } else {
+        if x <= 0.0 || x >= 1.0 {
             0.0
+        } else {
+            2.0 * x
         }
     }
 }


### PR DESCRIPTION
This commit addresses three critical bugs that were affecting the engine's performance and correctness:

1. **SCReLU Derivative Bug**: Fixed incorrect derivative calculation in the SCReLU activation function. Changed from `2.0 * x.sqrt()` to `2.0 * x` for the range [0, 1].

2. **Data Race in Transposition Table**: Fixed unsynchronized edge statistics copying that could lead to inconsistent data. Upgraded atomic operations from `Ordering::Relaxed` to `Ordering::Acquire/Release` to minimize the race window.

3. **Virtual Loss Bug**: Fixed incorrect virtual loss removal during backpropagation. Separated the evaluation update from virtual loss removal to ensure virtual loss is always added back as a positive value, regardless of the evaluation's sign.

These fixes improve the engine's statistical accuracy, parallel search efficiency, and overall playing strength.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a virtual loss mechanism in Monte Carlo Tree Search to improve multi-threaded performance.

- **Bug Fixes**
  - Corrected the derivative calculation for the SCReLU activation function, ensuring more accurate results.

- **Improvements**
  - Enhanced synchronization and atomic memory ordering for edge updates, increasing reliability in concurrent scenarios.
  - Added a debug-only method to help detect concurrent modifications during edge replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->