### PR TITLE
👌 IMP: Move goober usage to only the training crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,6 @@ dependencies = [
  "bytemuck",
  "cc",
  "fastapprox",
- "goober",
  "nohash-hasher",
  "scc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ default-members = [".", "crates/princhess-train"]
 
 [workspace.dependencies]
 arrayvec = "=0.7.6"
-goober = { git = "https://github.com/jw1912/goober/", rev = "32b9b52" }
 princhess = { version = "0.0.0-dev", path = "." }
 
 [workspace.dependencies.bytemuck]
@@ -35,7 +34,6 @@ features = [
 arrayvec = { workspace = true }
 bytemuck = { workspace = true }
 fastapprox = "=0.3.1"
-goober = { workspace = true }
 nohash-hasher = "=0.2.0"
 scc = "=2.3.0"
 

--- a/crates/princhess-train/Cargo.toml
+++ b/crates/princhess-train/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [dependencies]
 arrayvec = { workspace = true }
 bytemuck = { workspace = true }
-goober = { workspace = true }
+goober = { git = "https://github.com/jw1912/goober/", rev = "32b9b52" }
 princhess = { path = "../../" }

--- a/crates/princhess-train/src/bin/train-policy.rs
+++ b/crates/princhess-train/src/bin/train-policy.rs
@@ -1,5 +1,6 @@
 use arrayvec::ArrayVec;
 use bytemuck::Zeroable;
+use goober::SparseVector;
 use princhess::math;
 use princhess::state::State;
 use princhess::train::TrainingPosition;
@@ -196,8 +197,10 @@ fn update_gradient(
     acc: &mut f32,
 ) {
     let state = State::from(position);
-    let features = position.get_policy_features();
     let moves = position.moves();
+
+    let mut features = SparseVector::with_capacity(64);
+    state.policy_features_map(|feature| features.push(feature));
 
     let only_moves = moves.iter().map(|(mv, _)| *mv).collect();
     let move_idxes = state.moves_to_indexes(&only_moves).collect::<Vec<_>>();

--- a/crates/princhess-train/src/bin/train-value.rs
+++ b/crates/princhess-train/src/bin/train-value.rs
@@ -1,4 +1,5 @@
-use goober::{FeedForwardNetwork, OutputLayer, Vector};
+use goober::{FeedForwardNetwork, OutputLayer, SparseVector, Vector};
+use princhess::state::State;
 use princhess::train::TrainingPosition;
 use std::env;
 use std::fs::{self, File};
@@ -168,7 +169,8 @@ fn update_gradient(
     gradients: &mut ValueNetwork,
     loss: &mut f32,
 ) {
-    let features = position.get_value_features();
+    let mut features = SparseVector::with_capacity(64);
+    State::from(position).value_features_map(|feature| features.push(feature));
 
     let net_out = network.out_with_layers(&features);
 

--- a/src/bin/data-summary.rs
+++ b/src/bin/data-summary.rs
@@ -1,3 +1,4 @@
+use arrayvec::ArrayVec;
 use princhess::nets::MoveIndex; // Corrected import path
 use princhess::state::{self, State};
 use princhess::train::TrainingPosition;
@@ -51,9 +52,11 @@ fn main() {
         }
 
         for position in positions.iter() {
-            let features = position.get_policy_features();
-            let moves = position.moves().iter().map(|(mv, _)| *mv).collect();
             let state = State::from(position);
+            let moves = position.moves().iter().map(|(mv, _)| *mv).collect();
+
+            let mut features = ArrayVec::<usize, 64>::new();
+            state.policy_features_map(|feature| features.push(feature));
 
             let material_balance_idx = (state.material_balance() + 12).clamp(0, 24) as usize;
 

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -1,9 +1,6 @@
-use goober::SparseVector;
-
 use crate::chess::MoveList;
-use crate::math;
-
 use crate::engine::SCALE;
+use crate::math;
 use crate::quantized_policy::QuantizedPolicyNetwork;
 use crate::quantized_value::QuantizedValueNetwork;
 use crate::state::State;
@@ -108,16 +105,13 @@ fn run_policy_net(_state: &State, moves: &MoveList, _t: f32) -> Vec<f32> {
 
 #[cfg(feature = "policy-net")]
 fn run_policy_net(state: &State, moves: &MoveList, t: f32) -> Vec<f32> {
-    let mut features = SparseVector::with_capacity(32);
-    state.policy_features_map(|idx| features.push(idx));
-
     let mut evalns = vec![0.0; moves.len()];
 
     if moves.is_empty() {
         return evalns;
     }
 
-    POLICY_NETWORK.get_all(&features, state.moves_to_indexes(moves), &mut evalns);
+    POLICY_NETWORK.get_all(state, state.moves_to_indexes(moves), &mut evalns);
 
     math::softmax(&mut evalns, t);
 

--- a/src/quantized_policy.rs
+++ b/src/quantized_policy.rs
@@ -23,7 +23,8 @@ type RawLinearBias = Align16<[i16; ATTENTION_SIZE]>;
 type QuantizedLinearWeights = [Align16<Accumulator<i16, ATTENTION_SIZE>>; INPUT_SIZE];
 type QuantizedLinearBias = Align16<Accumulator<i16, ATTENTION_SIZE>>;
 
-type FeatureVector = ArrayVec<usize, 64>;
+// Max number of features is 1 per piece
+type FeatureVector = ArrayVec<usize, 32>;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]

--- a/src/train/data.rs
+++ b/src/train/data.rs
@@ -1,6 +1,5 @@
 use arrayvec::ArrayVec;
 use bytemuck::{self, Pod, Zeroable};
-use goober::SparseVector;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::mem;
@@ -85,26 +84,6 @@ impl TrainingPosition {
 
     pub fn set_result(&mut self, result: i8) {
         self.result = result;
-    }
-
-    #[must_use]
-    pub fn get_value_features(&self) -> SparseVector {
-        let mut features = SparseVector::with_capacity(64);
-        let state = State::from(self);
-
-        state.value_features_map(|idx| features.push(idx));
-
-        features
-    }
-
-    #[must_use]
-    pub fn get_policy_features(&self) -> SparseVector {
-        let mut features = SparseVector::with_capacity(64);
-        let state = State::from(self);
-
-        state.policy_features_map(|idx| features.push(idx));
-
-        features
     }
 }
 


### PR DESCRIPTION
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 0.76 +/- 4.96, nElo: 1.41 +/- 9.20
sprt_equal-1  | LOS: 61.81 %, DrawRatio: 53.05 %, PairsRatio: 0.99
sprt_equal-1  | Games: 5482, Wins: 1142, Losses: 1130, Draws: 3210, Points: 2747.0 (50.11 %)
sprt_equal-1  | Ptnml(0-2): [43, 603, 1454, 581, 60], WL/DD Ratio: 0.44
sprt_equal-1  | LLR: 2.91 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------

sprt_equal_2t-1  | --------------------------------------------------
sprt_equal_2t-1  | Results of princhess vs princhess-main (8+0.08, 2t, 256MB, UHO_Lichess_4852_v1.epd):
sprt_equal_2t-1  | Elo: 0.27 +/- 4.47, nElo: 0.53 +/- 8.57
sprt_equal_2t-1  | LOS: 54.80 %, DrawRatio: 52.11 %, PairsRatio: 1.01
sprt_equal_2t-1  | Games: 6318, Wins: 1321, Losses: 1316, Draws: 3681, Points: 3161.5 (50.04 %)
sprt_equal_2t-1  | Ptnml(0-2): [37, 714, 1646, 731, 31], WL/DD Ratio: 0.47
sprt_equal_2t-1  | LLR: 2.89 (100.1%) (-2.25, 2.89) [-10.00, 0.00]
sprt_equal_2t-1  | --------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated feature extraction to use direct state-based mapping, improving how features are collected and passed to policy and value networks.
  - Changed dependency management for an external library to use a direct Git reference.

- **Breaking Changes**
  - Modified policy network evaluation to accept state objects instead of feature vectors.
  - Removed public methods for obtaining value and policy features from training positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->