### PR TITLE
🐛 FIX: handle castling moves correctly in board updates

### DIFF
--- a/src/chess/board.rs
+++ b/src/chess/board.rs
@@ -350,7 +350,14 @@ impl Board {
 
         let color = self.stm;
         let piece = self.piece_at(mov.from());
-        let capture = self.piece_at(mov.to());
+
+        // Castling moves are represented as king moving to rook's square.
+        // This means `mov.to()` will contain the rook, but it's not a capture.
+        let capture = if mov.is_castle() {
+            Piece::NONE
+        } else {
+            self.piece_at(mov.to())
+        };
 
         let is_zeroing_move = piece == Piece::PAWN || capture != Piece::NONE;
 

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -558,10 +558,6 @@ pub fn principal_variation<'a>(
         // Unwrap the option here, as the loop condition implies it won't be None
         let choice = choice_option.expect("Expected a child move, but node had no edges.");
 
-        if result.iter().any(|x| x.get_move() == choice.get_move()) {
-            break;
-        }
-
         result.push(choice);
 
         state.make_move(*choice.get_move());


### PR DESCRIPTION
```
sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 5.74 +/- 7.69, nElo: 10.76 +/- 14.39
sprt_equal-1  | LOS: 92.86 %, DrawRatio: 51.47 %, PairsRatio: 1.12
sprt_equal-1  | Games: 2238, Wins: 496, Losses: 459, Draws: 1283, Points: 1137.5 (50.83 %)
sprt_equal-1  | Ptnml(0-2): [13, 243, 576, 268, 19], WL/DD Ratio: 0.49
sprt_equal-1  | LLR: 2.91 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------

debug_6t-1  | --------------------------------------------------
debug_6t-1  | Rank Name                             Elo        +/-       nElo        +/-      Games      Score       Draw           Ptnml(0-2)
debug_6t-1  |    1 princhess-main                  5.21      18.50       9.60      34.05        400      50.7%      45.5%   [1, 51, 91, 55, 2]
debug_6t-1  |    2 princhess-right                 1.74      15.98       3.70      34.05        400      50.2%      56.0%  [0, 43, 112, 45, 0]
debug_6t-1  |    3 princhess-left                 -6.95      17.52     -13.52      34.05        400      49.0%      51.5%  [2, 50, 103, 44, 1]
debug_6t-1  | --------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of castling moves to prevent incorrectly marking the rook as captured during castling.
- **Refactor**
  - Updated principal variation logic to allow repeated moves in the sequence, improving consistency with game state progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->