### PR TITLE
👌 IMP: Use PathBuf for output file path and fix buffer copy

### DIFF
--- a/crates/princhess-train/src/bin/data-gen.rs
+++ b/crates/princhess-train/src/bin/data-gen.rs
@@ -411,7 +411,7 @@ fn main() {
                             positions.drain(..TrainingPosition::BUFFER_COUNT).as_slice(),
                         );
 
-                        TrainingPosition::write_buffer(&mut writer, &buffer);
+                        TrainingPosition::write_buffer(&mut writer, &buffer[..]);
                     }
                 });
             }

--- a/crates/princhess-train/src/bin/data-shuffle.rs
+++ b/crates/princhess-train/src/bin/data-shuffle.rs
@@ -69,7 +69,7 @@ fn main() {
             let chunk_size = positions.len().min(TrainingPosition::BUFFER_COUNT);
             buffer[..chunk_size]
                 .copy_from_slice(&positions.drain(..chunk_size).collect::<Vec<_>>());
-            TrainingPosition::write_buffer(&mut writer, &buffer);
+            TrainingPosition::write_buffer(&mut writer, &buffer[..chunk_size]);
         }
 
         println!("Done ({}ms).", start.elapsed().as_millis());

--- a/crates/princhess-train/src/bin/data-shuffle.rs
+++ b/crates/princhess-train/src/bin/data-shuffle.rs
@@ -3,6 +3,7 @@ use princhess::math::Rng;
 use std::env;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::path::PathBuf;
 use std::time::Instant;
 
 use princhess_train::data::TrainingPosition;
@@ -54,14 +55,20 @@ fn main() {
             }
         }
 
-        println!("Saving {input}.shuffled...");
+        let mut output_path = PathBuf::from(&input);
+        output_path.set_extension("shuffled");
+        let output_filename = output_path.to_string_lossy();
 
-        let mut writer = BufWriter::new(File::create(format!("{input}.shuffled")).unwrap());
+        println!("Saving {output_filename}...");
+
+        let mut writer = BufWriter::new(File::create(&output_path).unwrap());
         let mut buffer: Box<[TrainingPosition; TrainingPosition::BUFFER_COUNT]> =
             allocation::zeroed_box();
 
         while !positions.is_empty() {
-            buffer.copy_from_slice(positions.drain(..TrainingPosition::BUFFER_COUNT).as_slice());
+            let chunk_size = positions.len().min(TrainingPosition::BUFFER_COUNT);
+            buffer[..chunk_size]
+                .copy_from_slice(&positions.drain(..chunk_size).collect::<Vec<_>>());
             TrainingPosition::write_buffer(&mut writer, &buffer);
         }
 

--- a/crates/princhess-train/src/data.rs
+++ b/crates/princhess-train/src/data.rs
@@ -33,8 +33,8 @@ impl TrainingPosition {
     pub const BUFFER_COUNT: usize = 1 << 16;
     pub const BUFFER_SIZE: usize = Self::BUFFER_COUNT * Self::SIZE;
 
-    pub fn write_buffer(out: &mut BufWriter<File>, data: &[TrainingPosition; Self::BUFFER_COUNT]) {
-        out.write_all(bytemuck::bytes_of(data)).unwrap();
+    pub fn write_buffer(out: &mut BufWriter<File>, data: &[TrainingPosition]) {
+        out.write_all(bytemuck::cast_slice(data)).unwrap();
     }
 
     #[must_use]


### PR DESCRIPTION
Fixes #430 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of output filenames for shuffled data files.
  * Enhanced buffer management for more efficient processing of remaining data.
  * Updated data writing to support flexible buffer sizes for better serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->