### PR TITLE
👌 IMP: Refactor PV difference calculation and adjust default params

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -341,9 +341,15 @@ impl Mcts {
             let bm_eval = bm_reward.average;
             let bm_pv_eval = pv_eval(self.root_state.clone(), bm, pv_eval_depth);
 
-            if (bm_eval - bm_pv_eval).abs() > (opts.pv_diff_c * SCALE) as i64 {
-                m *= opts.pv_diff_m;
-            }
+            let diff_abs_normalized = (bm_eval - bm_pv_eval).abs() as f32 / SCALE;
+
+            // `opts.pv_diff_c` is the threshold for the normalized PV difference.
+            // `opts.pv_diff_m` is the scaling factor for the time multiplier adjustment.
+            // The adjustment can be positive (increase time) or negative (decrease time)
+            // depending on whether `diff_abs_normalized` is above or below `opts.pv_diff_c`.
+            let adjustment = (diff_abs_normalized - opts.pv_diff_c) * opts.pv_diff_m;
+
+            m *= 1.0 + adjustment;
         }
 
         m = m.clamp(opts.min_m, opts.max_m);

--- a/src/options.rs
+++ b/src/options.rs
@@ -100,8 +100,8 @@ static TM_MIN_M: UciOption = UciOption::spin("TMMinM", 10, 0, 2 << 16);
 static TM_MAX_M: UciOption = UciOption::spin("TMMaxM", 500, 0, 2 << 16);
 static TM_VISITS_BASE: UciOption = UciOption::spin("TMVisitsBase", 140, 0, 2 << 16);
 static TM_VISITS_M: UciOption = UciOption::spin("TMVisitsM", 139, 0, 2 << 16);
-static TM_PV_DIFF_C: UciOption = UciOption::spin("TMPvDiffC", 20, 0, 100);
-static TM_PV_DIFF_M: UciOption = UciOption::spin("TMPvDiffM", 461, 0, 2 << 16);
+static TM_PV_DIFF_C: UciOption = UciOption::spin("TMPvDiffC", 0, 0, 100);
+static TM_PV_DIFF_M: UciOption = UciOption::spin("TMPvDiffM", 121, 0, 2 << 16);
 
 static CHESS960: UciOption = UciOption::check("UCI_Chess960", false);
 static POLICY_ONLY: UciOption = UciOption::check("PolicyOnly", false);


### PR DESCRIPTION
```
sprt_gain_ltc-1  | --------------------------------------------------
sprt_gain_ltc-1  | Results of princhess vs princhess-main (40+0.4, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_gain_ltc-1  | Elo: 4.40 +/- 4.14, nElo: 8.83 +/- 8.31
sprt_gain_ltc-1  | LOS: 98.13 %, DrawRatio: 54.81 %, PairsRatio: 1.12
sprt_gain_ltc-1  | Games: 6710, Wins: 1292, Losses: 1207, Draws: 4211, Points: 3397.5 (50.63 %)
sprt_gain_ltc-1  | Ptnml(0-2): [27, 687, 1839, 778, 24], WL/DD Ratio: 0.34
sprt_gain_ltc-1  | LLR: 2.13 (-1.50, 2.08) [0.00, 10.00]
sprt_gain_ltc-1  | --------------------------------------------------

sprt_equal-1  | --------------------------------------------------
sprt_equal-1  | Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
sprt_equal-1  | Elo: 1.41 +/- 5.26, nElo: 2.68 +/- 9.96
sprt_equal-1  | LOS: 70.07 %, DrawRatio: 54.35 %, PairsRatio: 1.07
sprt_equal-1  | Games: 4670, Wins: 950, Losses: 931, Draws: 2789, Points: 2344.5 (50.20 %)
sprt_equal-1  | Ptnml(0-2): [47, 469, 1269, 518, 32], WL/DD Ratio: 0.41
sprt_equal-1  | LLR: 2.97 (-2.25, 2.89) [-10.00, 0.00]
sprt_equal-1  | --------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the adjustment logic for time management, allowing for more flexible and continuous scaling based on evaluation differences.
  * Updated default values for time management options to improve behavior out of the box.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->