### PR TITLE
🐛 FIX: Update scc to 3.6.12 for Rust 1.94

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,15 +660,15 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "saa"
-version = "5.0.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2d7c5178d64caf296b798b8e96d8dcc4b6427bab402eeae2f65f4d76a08a4c"
+checksum = "16c7f49c9d5caa3bf4b3106900484b447b9253fe99670ceb81cb6cb5027855e1"
 
 [[package]]
 name = "scc"
-version = "3.3.1"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70210ae462e438f41d3645a859eb9e5f5c63533a58dbc6291b451cd0b5524148"
+checksum = "f448f7d881535036452f0cac656a41463807f095eda504890764ca7d11e2a2ea"
 dependencies = [
  "saa",
  "sdd",
@@ -682,9 +682,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "4.2.4"
+version = "4.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8729f5224c38cb041e72fa9968dd4e379d3487b85359539d31d75ed95992d8"
+checksum = "e6ca0e33fc1ae39e36b2d1fdfc8ee470b26397b642ff87572a59a36ff4f2340b"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [".", "crates/princhess-train"]
 [workspace.dependencies]
 arrayvec = "=0.7.6"
 princhess = { version = "0.0.0-dev", path = "." }
-scc = "=3.3.1"
+scc = "=3.6.12"
 
 [workspace.dependencies.bytemuck]
 version = "=1.24.0"


### PR DESCRIPTION
```
--------------------------------------------------
Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
Elo: -2.76 +/- 3.06, nElo: -5.01 +/- 5.56
LOS: 3.86 %, DrawRatio: 51.00 %, PairsRatio: 0.95
Games: 15000, Wins: 3291, Losses: 3410, Draws: 8299, Points: 7440.5 (49.60 %)
Ptnml(0-2): [153, 1735, 3825, 1652, 135], WL/DD Ratio: 0.56
LLR: -0.01 (-0.6%) (-2.25, 2.89) [-10.00, 0.00]
--------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to a newer version for enhanced stability and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->