### PR TITLE
📦 NEW: Add Top Two root selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Princhess is a chess engine written in Rust. It implements a Monte Carlo Tree Se
 *   **DAG-Based MCTS:** Uses a directed acyclic graph rather than a tree to support transpositions. Rewards and visit counts are stored on edges instead of nodes.
 *   **Dynamic CPUCT Adjustments:** Multiple mechanisms for adjusting exploration including Gini impurity, per-thread jitter for search diversity, and trend-based adjustments for winning/losing positions.
 *   **Custom Memory Allocator:** Includes an arena memory allocator with half flipping for managing the MCTS graph within a fixed memory size, allowing unbounded search depth with bounded memory usage.
+*   **Top Two Root Selection:** Uses the Top Two sampling rule for root move selection, based on [EB-TCε](https://arxiv.org/abs/2305.16041). Treats root move selection as a best arm identification problem, using transportation cost to identify the leader and challenger.
 *   **Phase-Aware Policy Networks:** Dynamically loads separate policy networks for middle-game and endgame phases.
 *   **Endgame Tablebase Integration:** Integrates with Fathom tablebases for endgame evaluation.
 *   **Self-Play & Training Infrastructure:** The `princhess-train` crate provides tools for self-play data generation. The policy and value networks are trained on this self-play data and are designed to be small enough to run efficiently on the CPU.
@@ -65,7 +66,6 @@ The engine responds to standard UCI commands.
 - **CPuctGiniMax** (default: 210): Maximum value for Gini-scaled exploration coefficient
 - **CVisitsSelection** (default: 1): How much to consider visits vs Q-value in final move selection
 - **PolicyTemperature** (default: 100): Softmax temperature for policy network during node expansion
-- **PolicyTemperatureRoot** (default: 1450): Separate policy temperature specifically for root node
 
 ### Time Management
 Adaptive time allocation controls:

--- a/crates/princhess-train/src/analysis.rs
+++ b/crates/princhess-train/src/analysis.rs
@@ -21,6 +21,9 @@ pub fn write_lr_analysis_toml(
     grad_l1: &[f32],
     lr_full: &[f32],
 ) {
+    const WARMUP_FINE_SBS: usize = 2;
+    const WARMUP_BINS_PER_SB: usize = 10;
+
     if grad_l1.is_empty() || lr_full.is_empty() {
         return;
     }
@@ -79,8 +82,6 @@ pub fn write_lr_analysis_toml(
     }
 
     // Fine-grained warmup analysis: 10 bins each for SB1 and SB2
-    const WARMUP_FINE_SBS: usize = 2;
-    const WARMUP_BINS_PER_SB: usize = 10;
     let fine_steps = (steps_per_sb * WARMUP_FINE_SBS).min(t);
     let bin_size = fine_steps / (WARMUP_FINE_SBS * WARMUP_BINS_PER_SB);
     let mut warmup_analysis = Vec::new();
@@ -89,7 +90,7 @@ pub fn write_lr_analysis_toml(
             let start = bin * bin_size;
             let end = ((bin + 1) * bin_size).min(t);
             let len = (end - start) as f32;
-            let step_mid = (start + end) / 2;
+            let step_mid = usize::midpoint(start, end);
             let actual_avg = lr_full[start..end].iter().sum::<f32>() / len;
             let proposed_avg = proposal[start..end].iter().sum::<f32>() / len;
             let grad_l1_avg = grad_l1[start..end].iter().sum::<f32>() / len;
@@ -107,8 +108,7 @@ pub fn write_lr_analysis_toml(
         .iter()
         .enumerate()
         .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, v)| (i + 1, v))
-        .unwrap_or((0, &0.0));
+        .map_or((0, &0.0), |(i, v)| (i + 1, v));
     let peak_actual = lr_full.get(peak_step).copied().unwrap_or(0.0);
     let mut warmup_peak = Table::new();
     warmup_peak.insert("step".into(), Value::Integer(peak_step as i64));
@@ -174,6 +174,7 @@ impl Ord for OrdF32 {
 }
 
 // Two-heap sliding median with lazy deletion. O(T log W).
+#[allow(clippy::too_many_lines)]
 fn sliding_median(data: &[f32], width: usize) -> Vec<f32> {
     let n = data.len();
     if n == 0 {

--- a/crates/princhess-train/src/bin/data-gen.rs
+++ b/crates/princhess-train/src/bin/data-gen.rs
@@ -48,7 +48,6 @@ const KL_DIVERGENCE_THRESHOLD: f32 = 0.000_002;
 const CPUCT: f32 = 2.82;
 const CPUCT_JITTER: f32 = 0.05;
 const POLICY_TEMPERATURE: f32 = 1.0;
-const POLICY_TEMPERATURE_ROOT: f32 = 1.4;
 
 const MAX_THREADS: u16 = 64;
 const DFRC_PCT: u64 = 10;
@@ -1620,10 +1619,6 @@ fn write_toml(path: &str, stats: &Stats, files: &[String], threads: u16, max_pos
     p.insert("cpuct_jitter".into(), CPUCT_JITTER.into());
     p.insert("policy_temperature".into(), POLICY_TEMPERATURE.into());
     p.insert(
-        "policy_temperature_root".into(),
-        POLICY_TEMPERATURE_ROOT.into(),
-    );
-    p.insert(
         "max_playouts_per_position".into(),
         Value::Integer(i64::try_from(MAX_PLAYOUTS_PER_POSITION).unwrap_or(i64::MAX)),
     );
@@ -1713,7 +1708,6 @@ fn main() {
                     cpuct_gini_factor: 0.0,
                     cpuct_gini_max: 1.0,
                     policy_temperature: POLICY_TEMPERATURE,
-                    policy_temperature_root: POLICY_TEMPERATURE_ROOT,
                 };
 
                 let engine_options = EngineOptions {

--- a/crates/princhess-train/src/neural/layers.rs
+++ b/crates/princhess-train/src/neural/layers.rs
@@ -207,6 +207,7 @@ impl<T: Activation, const M: usize, const N: usize> MulAssign<f32> for SparseCon
 }
 
 impl<T: Activation, const M: usize, const N: usize> SparseConnected<T, M, N> {
+    #[must_use]
     pub fn activation_name() -> &'static str {
         T::name()
     }

--- a/crates/princhess-train/src/policy_subnets.rs
+++ b/crates/princhess-train/src/policy_subnets.rs
@@ -85,6 +85,7 @@ impl<const A: usize> DivAssign<f32> for SeeSplitSubnets<A> {
 }
 
 impl<const A: usize> SeeSplitSubnets<A> {
+    #[must_use]
     pub fn l1_norm(&self) -> f32 {
         self.base.l1_norm() + self.good_see.l1_norm()
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -98,6 +98,67 @@ impl RootEdge {
     }
 }
 
+pub struct TopTwoState {
+    challenger_deficit: f32,
+}
+
+impl TopTwoState {
+    fn new() -> Self {
+        Self {
+            challenger_deficit: 0.0,
+        }
+    }
+
+    pub fn next(&mut self, root_edges: &ArrayVec<RootEdge, 256>) -> usize {
+        let mut leader = 0;
+        let mut leader_avg = i64::MIN;
+        for (i, edge) in root_edges.iter().enumerate() {
+            let avg = edge.reward().average;
+            if avg > leader_avg {
+                leader_avg = avg;
+                leader = i;
+            }
+        }
+
+        let leader_reward = root_edges[leader].reward();
+        // 0 visits → ∞, so unvisited moves get tc_sq = 0 (best challenger)
+        let inv_n_leader = 1.0 / leader_reward.visits as f32;
+
+        let mut best_tc_sq = f32::INFINITY;
+        let mut challenger = 0;
+        let mut n_c = 0.0_f32;
+
+        for (i, edge) in root_edges.iter().enumerate() {
+            if i == leader {
+                continue;
+            }
+            let r = edge.reward();
+            let gap = (leader_avg - r.average) as f32 / SCALE;
+            let tc_sq = gap * gap / (inv_n_leader + 1.0 / r.visits as f32);
+            if tc_sq < best_tc_sq {
+                best_tc_sq = tc_sq;
+                challenger = i;
+                n_c = r.visits as f32;
+            }
+        }
+
+        let n_l = leader_reward.visits as f32;
+        let p_challenger = if n_l < n_c {
+            (n_l + 0.5) / (n_l + n_c + 1.0)
+        } else {
+            1.0 / (2.0 + best_tc_sq.max(0.0).sqrt())
+        };
+        self.challenger_deficit += p_challenger;
+
+        if self.challenger_deficit >= 1.0 {
+            self.challenger_deficit -= 1.0;
+            challenger
+        } else {
+            leader
+        }
+    }
+}
+
 pub struct ThreadData<'a> {
     pub ttable: &'a LRTable,
     pub allocator: LRAllocator<'a>,
@@ -108,6 +169,7 @@ pub struct ThreadData<'a> {
     pub tb_hits: usize,
     pub root_edges: ArrayVec<RootEdge, 256>,
     pub root_gini: f32,
+    pub top_two_state: TopTwoState,
 }
 
 impl<'a> ThreadData<'a> {
@@ -127,6 +189,7 @@ impl<'a> ThreadData<'a> {
             tb_hits: 0,
             root_edges,
             root_gini,
+            top_two_state: TopTwoState::new(),
         }
     }
 
@@ -382,20 +445,28 @@ impl Engine {
 
         let mut moves: Vec<(&MoveEdge, f32)> = node_moves.iter().zip(state_moves_eval).collect();
         moves.sort_by_key(|(h, e)| (h.reward().average, (e * SCALE) as i64));
+
+        let leader_reward = moves.last().map_or(Reward::ZERO, |(m, _)| m.reward());
+        let leader_avg = leader_reward.average;
+        let inv_n_leader = 1.0 / leader_reward.visits as f32;
+
         for (mov, e) in moves {
             let reward = mov.reward();
-            let u = mcts::exploration_bonus(explore_coef, mov.policy(), reward.visits);
+            #[allow(clippy::cast_sign_loss)]
+            let u = mcts::exploration_bonus(explore_coef, (e * SCALE) as u16, reward.visits);
+            let gap = (leader_avg - reward.average) as f32 / SCALE;
+            let tc = (gap * gap / (inv_n_leader + 1.0 / reward.visits as f32)).max(0.0).sqrt();
 
             println!(
-                "info string {:7} M: {:>5.2} P: {:>5.2} V: {:7} ({:>5.2}%) Q: {:>7.2} ({:>8}) U: {:>7.2}",
+                "info string {:7} M: {:>5.2} V: {:7} ({:>5.2}%) Q: {:>7.2} ({:>8}) U: {:>7.2} T: {:>7.2}",
                 self.to_uci(*mov.get_move()),
                 e * 100.,
-                f32::from(mov.policy()) / SCALE * 100.,
                 mov.visits(),
                 mov.visits() as f32 / total_visits as f32 * 100.,
                 reward.average as f32 / (SCALE / 100.),
                 eval_in_cp(reward.average as f32 / SCALE),
                 u as f32 / (SCALE / 100.),
+                tc,
             );
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -33,9 +33,10 @@ pub struct PositionNode {
     _padding: [u8; 8],
 }
 
+#[derive(Clone, Copy)]
 pub struct Reward {
     pub average: i64,
-    pub visits: u32, // This is fine as visits count up, not related to evaluation magnitude
+    pub visits: u32,
 }
 
 impl Reward {

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -51,17 +51,9 @@ impl Mcts {
     /// Creates a new MCTS instance with the given root state.
     pub fn new(state: State, table: &LRTable, engine_options: EngineOptions) -> Self {
         let moves = state.available_moves();
-        let move_eval = evaluation::policy(
-            &state,
-            &moves,
-            engine_options.mcts_options.policy_temperature_root,
-        );
-
         let mut root_edges = Vec::with_capacity(moves.len());
-        #[allow(clippy::cast_sign_loss)]
-        for i in 0..move_eval.len() {
-            let policy_val = (move_eval[i] * SCALE) as u16;
-            root_edges.push(MoveEdge::new(policy_val, moves[i]));
+        for mv in &moves {
+            root_edges.push(MoveEdge::new(0, *mv));
         }
 
         // Warm-start: copy statistics from transposition table if available
@@ -122,7 +114,7 @@ impl Mcts {
             tld.root_gini = math::gini(tld.root_edges.iter().map(RootEdge::visits), total_visits);
         }
 
-        let root_edge_idx = self.select_root_edge(tld, options, total_visits);
+        let root_edge_idx = tld.top_two_state.next(&tld.root_edges);
         let root_edge_ref = &self.root_edges[root_edge_idx];
 
         let mut state = self.root_state.clone();
@@ -566,40 +558,6 @@ impl Mcts {
         // Calculate exploration coefficient
         (cpuct * faster::exp(options.cpuct_tau * faster::ln((total_visits + 1) as f32)) * SCALE)
             as i64
-    }
-
-    /// PUCT selection for root node using thread-local buffered statistics.
-    fn select_root_edge(
-        &self,
-        tld: &ThreadData,
-        options: &MctsOptions,
-        total_visits: u64,
-    ) -> usize {
-        let edges = &self.root_edges;
-
-        let explore_coef = self.exploration_coefficient(
-            options,
-            total_visits,
-            tld.is_main_thread(),
-            tld.root_gini,
-        );
-
-        let mut best_idx = 0;
-        let mut best_score = i64::MIN;
-
-        for (idx, edge) in edges.iter().enumerate() {
-            let reward = tld.root_edges[idx].reward();
-            let q = if reward.visits > 0 { reward.average } else { 0 };
-            let u = exploration_bonus(explore_coef, edge.policy(), reward.visits);
-            let score = q + u;
-
-            if score > best_score {
-                best_score = score;
-                best_idx = idx;
-            }
-        }
-
-        best_idx
     }
 
     /// PUCT selection: choose best child using Q(action) + U(action)

--- a/src/options.rs
+++ b/src/options.rs
@@ -98,8 +98,6 @@ static CPUCT_GINI_FACTOR: UciOption = UciOption::spin("CPuctGiniFactor", 163, 0,
 static CPUCT_GINI_MAX: UciOption = UciOption::spin("CPuctGiniMax", 210, 0, 2 << 16);
 static CVISITS_SELECTION: UciOption = UciOption::spin("CVisitsSelection", 1, 0, 100);
 static POLICY_TEMPERATURE: UciOption = UciOption::spin("PolicyTemperature", 100, 0, 2 << 16);
-static POLICY_TEMPERATURE_ROOT: UciOption =
-    UciOption::spin("PolicyTemperatureRoot", 1450, 0, 2 << 16);
 
 static TM_MIN_M: UciOption = UciOption::spin("TMMinM", 10, 0, 2 << 16);
 static TM_MAX_M: UciOption = UciOption::spin("TMMaxM", 500, 0, 2 << 16);
@@ -130,7 +128,6 @@ static ALL_OPTIONS: &[UciOption] = &[
     CPUCT_GINI_MAX,
     CVISITS_SELECTION,
     POLICY_TEMPERATURE,
-    POLICY_TEMPERATURE_ROOT,
     TM_MIN_M,
     TM_MAX_M,
     TM_VISITS_BASE,
@@ -222,7 +219,6 @@ pub struct MctsOptions {
     pub cpuct_gini_factor: f32,
     pub cpuct_gini_max: f32,
     pub policy_temperature: f32,
-    pub policy_temperature_root: f32,
 }
 
 #[allow(clippy::module_name_repetitions, clippy::struct_excessive_bools)]
@@ -284,7 +280,6 @@ impl From<&UciOptionMap> for MctsOptions {
             cpuct_gini_factor: map.get_f32(&CPUCT_GINI_FACTOR),
             cpuct_gini_max: map.get_f32(&CPUCT_GINI_MAX),
             policy_temperature: map.get_f32(&POLICY_TEMPERATURE),
-            policy_temperature_root: map.get_f32(&POLICY_TEMPERATURE_ROOT),
         }
     }
 }


### PR DESCRIPTION
Based on this paper: https://arxiv.org/pdf/2305.16041

```
--------------------------------------------------
Results of princhess vs princhess-main (40+0.4, 1t, 128MB, UHO_Lichess_4852_v1.epd):
Elo: 5.59 +/- 4.03, nElo: 11.23 +/- 8.09
LOS: 99.67 %, DrawRatio: 54.63 %, PairsRatio: 1.15
Games: 7080, Wins: 1427, Losses: 1313, Draws: 4340, Points: 3597.0 (50.81 %)
Ptnml(0-2): [26, 720, 1934, 834, 26], WL/DD Ratio: 0.39
LLR: 2.89 (100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------

-------------------------------------------------
Results of princhess vs princhess-main (8+0.08, 2t, 128MB, UHO_Lichess_4852_v1.epd):
Elo: 1.72 +/- 3.56, nElo: 3.26 +/- 6.77
LOS: 82.74 %, DrawRatio: 51.45 %, PairsRatio: 1.04
Games: 10126, Wins: 2135, Losses: 2085, Draws: 5906, Points: 5088.0 (50.25 %)
Ptnml(0-2): [59, 1144, 2605, 1198, 57], WL/DD Ratio: 0.46
LLR: 2.92 (100.9%) (-2.25, 2.89) [-3.00, 0.00]
--------------------------------------------------

-------------------------------------------------
Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
Elo: 17.64 +/- 8.66, nElo: 31.45 +/- 15.41
LOS: 100.00 %, DrawRatio: 48.77 %, PairsRatio: 1.42
Games: 1952, Wins: 468, Losses: 369, Draws: 1115, Points: 1025.5 (52.54 %)
Ptnml(0-2): [14, 193, 476, 266, 27], WL/DD Ratio: 0.45
LLR: 2.90 (100.3%) (-2.25, 2.89) [-3.00, 0.00]
--------------------------------------------------

--------------------------------------------------
Results of princhess vs princhess-main (40+0.4, 1t, 128MB, DFRC_4852_v1.epd):
Elo: 2.02 +/- 3.73, nElo: 3.71 +/- 6.87
LOS: 85.51 %, DrawRatio: 50.30 %, PairsRatio: 1.04
Games: 9818, Wins: 1994, Losses: 1937, Draws: 5887, Points: 4937.5 (50.29 %)
Ptnml(0-2): [74, 1120, 2469, 1167, 79], WL/DD Ratio: 0.37
LLR: 2.90 (100.5%) (-2.25, 2.89) [-3.00, 0.00]
--------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated root-move selection to choose between the leading move and the statistically closest challenger.
  * Move-list output now displays policy-based exploration values and a statistical comparison metric.

* **Changes**
  * Removed the `PolicyTemperatureRoot` configuration option.
  * Updated training and data-generation documentation to reflect the revised root-selection approach.
  * Improved safety and diagnostics for internal analysis and API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->