### PR TITLE
👌 IMP: Rewrite UCI parser

### DIFF
--- a/src/chess/mv.rs
+++ b/src/chess/mv.rs
@@ -97,4 +97,77 @@ impl Move {
 
         format!("{from}{to}{promotion}")
     }
+
+    // match uci string on the stack without allocating any heap strings :)
+    #[must_use]
+    pub fn matches_uci(self, mov_str: &str, is_chess960: bool) -> bool {
+        let bytes = mov_str.as_bytes();
+        if bytes.len() != 4 && bytes.len() != 5 {
+            return false;
+        }
+
+        let from = self.from();
+        let to = if self.is_castle() && !is_chess960 {
+            match self.to() {
+                Square::H1 => Square::G1,
+                Square::A1 => Square::C1,
+                Square::H8 => Square::G8,
+                Square::A8 => Square::C8,
+                _ => return false,
+            }
+        } else {
+            self.to()
+        };
+
+        let from_idx = from.index() as u8;
+        let to_idx = to.index() as u8;
+
+        if bytes[0] != b'a' + (from_idx % 8) || bytes[1] != b'1' + (from_idx / 8) {
+            return false;
+        }
+
+        if bytes[2] != b'a' + (to_idx % 8) || bytes[3] != b'1' + (to_idx / 8) {
+            return false;
+        }
+
+        let promo = self.promotion().to_promotion_char();
+        if promo.is_empty() {
+            bytes.len() == 4
+        } else {
+            bytes.len() == 5 && bytes[4] == promo.as_bytes()[0]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matches_uci_normal() {
+        let m = Move::new(Square::E2, Square::E4);
+        assert!(m.matches_uci("e2e4", false));
+        assert!(!m.matches_uci("e2e5", false));
+        assert!(!m.matches_uci("e3e4", false));
+        assert!(!m.matches_uci("e2e4q", false));
+    }
+
+    #[test]
+    fn test_matches_uci_promotion() {
+        let m = Move::new_promotion(Square::E7, Square::E8, Piece::QUEEN);
+        assert!(m.matches_uci("e7e8q", false));
+        assert!(!m.matches_uci("e7e8r", false));
+        assert!(!m.matches_uci("e7e8", false));
+    }
+
+    #[test]
+    fn test_matches_uci_castling() {
+        let m = Move::new_castle(Square::E1, Square::H1);
+        // standard chess: king lands on g1
+        assert!(m.matches_uci("e1g1", false));
+        assert!(!m.matches_uci("e1h1", false));
+        // chess960: king lands on rook square h1
+        assert!(m.matches_uci("e1h1", true));
+        assert!(!m.matches_uci("e1g1", true));
+    }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -15,8 +15,7 @@ use crate::state::State;
 use crate::tablebase;
 use crate::threadpool::{Scope, ThreadPool};
 use crate::time_management::TimeManagement;
-use crate::transposition_table::{LRAllocator, LRTable};
-use crate::uci::{self, Tokens};
+use crate::uci::{self, GoParams};
 
 pub const SCALE: f32 = 256. * 256.;
 
@@ -256,7 +255,7 @@ impl Engine {
         self.ttable.flip(|| self.mcts.clear_root_children_links());
     }
 
-    pub fn go(&self, tokens: Tokens, is_interactive: bool) -> Option<String> {
+    pub fn go(&self, params: &GoParams, is_interactive: bool) -> Option<String> {
         let state = self.mcts.root_state();
         let mvs = state.available_moves();
 
@@ -283,7 +282,7 @@ impl Engine {
         }
 
         let think_time =
-            TimeManagement::from_tokens(tokens, state, self.engine_options.is_policy_only);
+            TimeManagement::from_go(params, state, self.engine_options.is_policy_only);
 
         self.playout_parallel(think_time, is_interactive)
     }
@@ -384,13 +383,14 @@ impl Engine {
         self.mcts.flush_thread_stats(&mut tld);
     }
 
-    pub fn print_move_list(&self, tokens: Tokens) {
+    pub fn print_move_list<S: AsRef<str>>(&self, moves: impl IntoIterator<Item = S>) {
         let mut current_node: Option<&PositionNode> = None;
         let mut current_edges = self.mcts.root_edges();
         let mut current_state = self.mcts.root_state().clone();
 
-        // Navigate down the tree following the move sequence
-        for move_str in tokens {
+        // walk down tree following move path
+        for move_elem in moves {
+            let move_str = move_elem.as_ref();
             let edge = current_edges
                 .iter()
                 .find(|e| self.to_uci(*e.get_move()) == move_str);
@@ -426,7 +426,7 @@ impl Engine {
             self.engine_options.mcts_options.policy_temperature,
         );
 
-        // Calculate exploration coefficient for Q+U display
+        // calc exploration coefficient for q+u display
         let (total_visits, gini) = if let Some(node) = current_node {
             (node.visits(), f32::from(node.gini()) / SCALE)
         } else {

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,8 +3,6 @@ use arrayvec::ArrayVec;
 use crate::chess::{Board, Color, File, Move, MoveList, Square};
 use crate::evaluation;
 use crate::math::Rng;
-use crate::nets::MoveIndex;
-use crate::uci::Tokens;
 
 pub const NUMBER_KING_BUCKETS: usize = 3;
 pub const NUMBER_THREAT_BUCKETS: usize = 4;
@@ -30,36 +28,6 @@ impl State {
         }
     }
 
-    #[must_use]
-    pub fn from_tokens(mut tokens: Tokens, is_chess960: bool) -> Option<Self> {
-        let mut result = match tokens.next()? {
-            "startpos" => Self::default(),
-            "fen" => {
-                let mut s = String::new();
-                for i in 0..6 {
-                    if i != 0 {
-                        s.push(' ');
-                    }
-                    s.push_str(tokens.next()?);
-                }
-                Self::from_fen(&s)
-            }
-            _ => return None,
-        };
-        match tokens.next() {
-            Some("moves") | None => (),
-            Some(_) => return None,
-        }
-        for mov_str in tokens {
-            for mov in result.available_moves() {
-                if mov.to_uci(is_chess960) == mov_str {
-                    result.make_move(mov);
-                    break;
-                }
-            }
-        }
-        Some(result)
-    }
 
     pub fn from_fen(fen: &str) -> Self {
         let board = Board::from_fen(fen);

--- a/src/time_management.rs
+++ b/src/time_management.rs
@@ -142,7 +142,6 @@ mod tests {
         parse_go(&mut tokens)
     }
 
-    // Test for "go infinite"
     #[test]
     fn test_from_go_infinite() {
         let state = State::default();
@@ -154,7 +153,6 @@ mod tests {
         assert_eq!(tm.node_limit(), usize::MAX);
     }
 
-    // Test for "go movetime <ms>"
     #[test]
     fn test_from_go_movetime() {
         let state = State::default();
@@ -166,7 +164,6 @@ mod tests {
         assert_eq!(tm.node_limit(), usize::MAX);
     }
 
-    // Test for "go nodes <n>"
     #[test]
     fn test_from_go_nodes() {
         let state = State::default();
@@ -182,7 +179,6 @@ mod tests {
         assert_eq!(tm.node_limit(), 100_000);
     }
 
-    // Test for "go wtime <ms> btime <ms>" (White to move)
     #[test]
     fn test_from_go_time_white_to_move() {
         let state = State::default(); // White to move by default, moves_left() = 43
@@ -204,7 +200,6 @@ mod tests {
         assert_eq!(tm.node_limit(), usize::MAX);
     }
 
-    // Test for "go wtime <ms> btime <ms>" (Black to move)
     #[test]
     fn test_from_go_time_black_to_move() {
         let state = State::from_fen(BLACK_TO_MOVE_FEN); // Set black to move
@@ -226,7 +221,6 @@ mod tests {
         assert_eq!(tm.node_limit(), usize::MAX);
     }
 
-    // Test for "go wtime <ms> btime <ms> winc <inc> binc <inc>" (White to move)
     #[test]
     fn test_from_go_time_inc_white_to_move() {
         let state = State::default();
@@ -249,7 +243,6 @@ mod tests {
         assert_eq!(tm.node_limit(), usize::MAX);
     }
 
-    // Test for "go wtime <ms> btime <ms> movestogo <n>"
     #[test]
     fn test_from_go_movestogo() {
         let state = State::default(); // moves_left() = 43
@@ -273,7 +266,6 @@ mod tests {
         assert_eq!(tm.node_limit(), usize::MAX);
     }
 
-    // Test for is_policy_only
     #[test]
     fn test_from_go_is_policy_only() {
         let state = State::default();
@@ -362,7 +354,6 @@ mod tests {
         );
     }
 
-    // Test for combined time and nodes
     #[test]
     fn test_from_go_time_and_nodes() {
         let state = State::default();
@@ -407,7 +398,6 @@ mod tests {
         assert_eq!(tm.hard_limit(), Some(expected_hard_limit));
     }
 
-    // Test for negative btime when it's white to move
     #[test]
     fn test_from_go_negative_btime_white_to_move() {
         let state = State::default(); // White to move
@@ -431,7 +421,6 @@ mod tests {
         assert_eq!(tm.node_limit(), usize::MAX);
     }
 
-    // Test for negative wtime when it's black to move
     #[test]
     fn test_from_go_negative_wtime_black_to_move() {
         let state = State::from_fen(BLACK_TO_MOVE_FEN); // Black to move

--- a/src/time_management.rs
+++ b/src/time_management.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::chess::Color;
 use crate::state::State;
-use crate::uci::Tokens;
+use crate::uci::GoParams;
 
 const DEFAULT_MOVE_TIME_SECS: u64 = 10;
 
@@ -75,94 +75,51 @@ impl TimeManagement {
         self.node_limit = node_limit;
     }
 
-    fn parse_ms(tokens: &mut Tokens) -> Option<Duration> {
-        tokens
-            .next()
-            .unwrap_or("")
-            .parse()
-            .ok()
-            .map(Duration::from_millis)
-    }
-
-    pub fn from_tokens(mut tokens: Tokens, state: &State, is_policy_only: bool) -> Self {
+    pub fn from_go(params: &GoParams, state: &State, is_policy_only: bool) -> Self {
         let stm = state.side_to_move();
 
-        let mut infinite = false;
-        let mut move_time = None;
-        let mut increment = Duration::ZERO;
-        let mut remaining = None;
-        let mut movestogo: Option<u32> = None;
-        let mut node_limit = usize::MAX;
+        let remaining = match stm {
+            Color::WHITE => params.wtime,
+            Color::BLACK => params.btime,
+        };
 
-        while let Some(s) = tokens.next() {
-            match s {
-                "infinite" => infinite = true,
-                "movetime" => move_time = Self::parse_ms(&mut tokens),
-                "wtime" => {
-                    if stm == Color::WHITE {
-                        remaining = Self::parse_ms(&mut tokens);
-                    }
-                }
-                "btime" => {
-                    if stm == Color::BLACK {
-                        remaining = Self::parse_ms(&mut tokens);
-                    }
-                }
-                "winc" => {
-                    if stm == Color::WHITE {
-                        increment = Self::parse_ms(&mut tokens).unwrap_or(Duration::ZERO);
-                    }
-                }
-                "binc" => {
-                    if stm == Color::BLACK {
-                        increment = Self::parse_ms(&mut tokens).unwrap_or(Duration::ZERO);
-                    }
-                }
-                "movestogo" => {
-                    movestogo = tokens.next().unwrap_or("").parse().ok();
-                }
-                "nodes" => {
-                    node_limit = tokens
-                        .next()
-                        .unwrap_or("")
-                        .parse()
-                        .ok()
-                        .unwrap_or(usize::MAX);
-                }
-                _ => (),
-            }
-        }
+        let increment = match stm {
+            Color::WHITE => params.winc.unwrap_or(Duration::ZERO),
+            Color::BLACK => params.binc.unwrap_or(Duration::ZERO),
+        };
 
         let mut think_time = TimeManagement::default();
 
-        if infinite {
+        if params.infinite {
             think_time = TimeManagement::infinite();
-        } else if let Some(mt) = move_time {
+        } else if let Some(mt) = params.movetime {
             think_time = TimeManagement::from_duration(mt);
         } else if let Some(r) = remaining {
-            // 20/27 is a heuristic to scale moves_left, aiming for an average of ~20 moves
-            let mut move_time_fraction = u32::from(state.moves_left()) * 20 / 27;
+            // scale moves_left with 20/27 heuristic, clamp to 1 so late endgame doesn't div by 0 :)
+            let mut move_time_fraction = (u32::from(state.moves_left()) * 20 / 27).max(1);
 
-            if let Some(m) = movestogo {
-                // If 'movestogo' is explicitly set, use it rather than moves_left
-                move_time_fraction = (m + 2).min(move_time_fraction);
+            if let Some(m) = params.movestogo {
+                // movestogo is set, use that over moves_left
+                move_time_fraction = (m + 2).min(move_time_fraction).max(1);
             }
 
             let r = r.saturating_sub(MOVE_OVERHEAD);
 
-            // Soft limit: ideal/target time per move.
+            // soft limit: ideal target time for this move
             let soft_limit = (r + move_time_fraction * increment) / move_time_fraction;
 
-            // Hard limit: safety net or maximum time to spend on this move.
+            // hard limit: safety cap at 1/3 remaining time
             let hard_limit = r / 3;
 
-            // Ensure the soft limit is never more than the hard limit.
+            // soft limit shouldn't exceed hard limit
             think_time = TimeManagement::from_limits(soft_limit.min(hard_limit), hard_limit);
         }
 
-        if is_policy_only {
-            node_limit = 1;
-        }
+        let node_limit = if is_policy_only {
+            1
+        } else {
+            params.nodes.unwrap_or(usize::MAX)
+        };
 
         think_time.set_node_limit(node_limit);
         think_time
@@ -173,21 +130,22 @@ impl TimeManagement {
 mod tests {
     use super::*;
     use crate::state::State;
+    use crate::uci::parser::{parse_go, Tokenizer};
 
-    // FEN for a position where Black is to move
+    // fen for black to move position
     const BLACK_TO_MOVE_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1";
 
-    // Helper to create tokens from a string
-    fn create_tokens(s: &str) -> Tokens<'_> {
-        s.split_whitespace()
+    fn parse_test_go(s: &str) -> GoParams {
+        let mut tokens = Tokenizer::new(s);
+        parse_go(&mut tokens)
     }
 
     // Test for "go infinite"
     #[test]
-    fn test_from_tokens_infinite() {
+    fn test_from_go_infinite() {
         let state = State::default();
-        let tokens = create_tokens("infinite");
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("infinite");
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         assert_eq!(tm.soft_limit(), None);
         assert_eq!(tm.hard_limit(), None);
@@ -196,10 +154,10 @@ mod tests {
 
     // Test for "go movetime <ms>"
     #[test]
-    fn test_from_tokens_movetime() {
+    fn test_from_go_movetime() {
         let state = State::default();
-        let tokens = create_tokens("movetime 10000"); // 10 seconds
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("movetime 10000"); // 10 seconds
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         assert_eq!(tm.soft_limit(), None);
         assert_eq!(tm.hard_limit(), Some(Duration::from_secs(10)));
@@ -208,10 +166,10 @@ mod tests {
 
     // Test for "go nodes <n>"
     #[test]
-    fn test_from_tokens_nodes() {
+    fn test_from_go_nodes() {
         let state = State::default();
-        let tokens = create_tokens("nodes 100000");
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("nodes 100000");
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         // Default time limits apply if not specified
         assert_eq!(tm.soft_limit(), None);
@@ -224,10 +182,10 @@ mod tests {
 
     // Test for "go wtime <ms> btime <ms>" (White to move)
     #[test]
-    fn test_from_tokens_time_white_to_move() {
+    fn test_from_go_time_white_to_move() {
         let state = State::default(); // White to move by default, moves_left() = 43
-        let tokens = create_tokens("wtime 60000 btime 50000"); // 60s for white, 50s for black
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 60000 btime 50000"); // 60s for white, 50s for black
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         let expected_remaining = Duration::from_millis(60000).saturating_sub(MOVE_OVERHEAD);
         let expected_move_time_fraction = u32::from(state.moves_left()) * 20 / 27; // 43 * 20 / 27 = 860 / 27 = 31
@@ -246,10 +204,10 @@ mod tests {
 
     // Test for "go wtime <ms> btime <ms>" (Black to move)
     #[test]
-    fn test_from_tokens_time_black_to_move() {
+    fn test_from_go_time_black_to_move() {
         let state = State::from_fen(BLACK_TO_MOVE_FEN); // Set black to move
-        let tokens = create_tokens("wtime 60000 btime 50000"); // 60s for white, 50s for black
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 60000 btime 50000"); // 60s for white, 50s for black
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         let expected_remaining = Duration::from_millis(50000).saturating_sub(MOVE_OVERHEAD);
         let expected_move_time_fraction = u32::from(state.moves_left()) * 20 / 27;
@@ -268,10 +226,10 @@ mod tests {
 
     // Test for "go wtime <ms> btime <ms> winc <inc> binc <inc>" (White to move)
     #[test]
-    fn test_from_tokens_time_inc_white_to_move() {
+    fn test_from_go_time_inc_white_to_move() {
         let state = State::default();
-        let tokens = create_tokens("wtime 60000 btime 50000 winc 1000 binc 500"); // 1s inc for white
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 60000 btime 50000 winc 1000 binc 500"); // 1s inc for white
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         let expected_remaining = Duration::from_millis(60000).saturating_sub(MOVE_OVERHEAD);
         let expected_increment = Duration::from_millis(1000);
@@ -291,15 +249,12 @@ mod tests {
 
     // Test for "go wtime <ms> btime <ms> movestogo <n>"
     #[test]
-    fn test_from_tokens_movestogo() {
+    fn test_from_go_movestogo() {
         let state = State::default(); // moves_left() = 43
-        let tokens = create_tokens("wtime 60000 btime 50000 movestogo 40");
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 60000 btime 50000 movestogo 40");
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         let expected_remaining = Duration::from_millis(60000).saturating_sub(MOVE_OVERHEAD);
-        // moves_left() = 43. 43 * 20 / 27 = 31.
-        // movestogo (40) + 2 = 42.
-        // min(42, 31) = 31.
         let expected_move_time_fraction = (40 + 2).min(u32::from(state.moves_left()) * 20 / 27);
         assert_eq!(expected_move_time_fraction, 31);
 
@@ -318,23 +273,23 @@ mod tests {
 
     // Test for is_policy_only
     #[test]
-    fn test_from_tokens_is_policy_only() {
+    fn test_from_go_is_policy_only() {
         let state = State::default();
-        let tokens = create_tokens("infinite"); // Time control doesn't matter much here
-        let tm = TimeManagement::from_tokens(tokens, &state, true); // is_policy_only = true
+        let params = parse_test_go("infinite"); // Time control doesn't matter much here
+        let tm = TimeManagement::from_go(&params, &state, true); // is_policy_only = true
 
         assert_eq!(tm.node_limit(), 1);
-        // Time limits should still be infinite as per "infinite" token
+        // Time limits should still be infinite as per "infinite"
         assert_eq!(tm.soft_limit(), None);
         assert_eq!(tm.hard_limit(), None);
     }
 
     // Edge case: remaining time less than MOVE_OVERHEAD
     #[test]
-    fn test_from_tokens_low_remaining_time() {
+    fn test_from_go_low_remaining_time() {
         let state = State::default();
-        let tokens = create_tokens("wtime 10 btime 10"); // 10ms remaining
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 10 btime 10"); // 10ms remaining
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         let expected_remaining = Duration::from_millis(10).saturating_sub(MOVE_OVERHEAD); // Should be 0ms
         assert_eq!(expected_remaining, Duration::ZERO);
@@ -352,13 +307,12 @@ mod tests {
 
     // Edge case: movestogo is 0
     #[test]
-    fn test_from_tokens_movestogo_zero() {
+    fn test_from_go_movestogo_zero() {
         let state = State::default();
-        let tokens = create_tokens("wtime 60000 btime 50000 movestogo 0");
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 60000 btime 50000 movestogo 0");
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         let expected_remaining = Duration::from_millis(60000).saturating_sub(MOVE_OVERHEAD);
-        // (0 + 2) = 2. min(2, 31) = 2.
         let expected_move_time_fraction = 2.min(u32::from(state.moves_left()) * 20 / 27);
         assert_eq!(expected_move_time_fraction, 2);
 
@@ -376,10 +330,10 @@ mod tests {
 
     // Test for missing time value (should fall back to default if parsing fails)
     #[test]
-    fn test_from_tokens_missing_time_value() {
+    fn test_from_go_missing_time_value() {
         let state = State::default();
-        let tokens = create_tokens("wtime btime 50000"); // wtime has no value
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime btime 50000"); // wtime has no value
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         // Should fall back to default if wtime/btime parsing fails
         assert_eq!(tm.soft_limit(), None);
@@ -392,10 +346,10 @@ mod tests {
 
     // Test for missing nodes value (should default to usize::MAX)
     #[test]
-    fn test_from_tokens_missing_nodes_value() {
+    fn test_from_go_missing_nodes_value() {
         let state = State::default();
-        let tokens = create_tokens("nodes"); // nodes has no value
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("nodes"); // nodes has no value
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         assert_eq!(tm.node_limit(), usize::MAX);
         // Default time limits apply
@@ -408,10 +362,10 @@ mod tests {
 
     // Test for combined time and nodes
     #[test]
-    fn test_from_tokens_time_and_nodes() {
+    fn test_from_go_time_and_nodes() {
         let state = State::default();
-        let tokens = create_tokens("wtime 60000 btime 50000 nodes 50000");
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 60000 btime 50000 nodes 50000");
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         let expected_remaining = Duration::from_millis(60000).saturating_sub(MOVE_OVERHEAD);
         let expected_move_time_fraction = u32::from(state.moves_left()) * 20 / 27;
@@ -430,10 +384,10 @@ mod tests {
 
     // Test for very large time values (should not overflow)
     #[test]
-    fn test_from_tokens_large_time_values() {
+    fn test_from_go_large_time_values() {
         let state = State::default();
-        let tokens = create_tokens("wtime 3600000000 btime 3600000000 winc 100000 binc 100000"); // 1 hour for each, 100s inc
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 3600000000 btime 3600000000 winc 100000 binc 100000"); // 1 hour for each, 100s inc
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         let expected_remaining = Duration::from_millis(3_600_000_000).saturating_sub(MOVE_OVERHEAD);
         let expected_increment = Duration::from_millis(100_000);
@@ -453,10 +407,10 @@ mod tests {
 
     // Test for negative btime when it's white to move
     #[test]
-    fn test_from_tokens_negative_btime_white_to_move() {
+    fn test_from_go_negative_btime_white_to_move() {
         let state = State::default(); // White to move
-        let tokens = create_tokens("wtime 60000 btime -1000"); // Negative btime
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime 60000 btime -1000"); // Negative btime
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         // Since btime is negative and it's white to move, 'remaining' for white should still be parsed.
         // The negative btime token will be ignored for white's time.
@@ -477,10 +431,10 @@ mod tests {
 
     // Test for negative wtime when it's black to move
     #[test]
-    fn test_from_tokens_negative_wtime_black_to_move() {
+    fn test_from_go_negative_wtime_black_to_move() {
         let state = State::from_fen(BLACK_TO_MOVE_FEN); // Black to move
-        let tokens = create_tokens("wtime -1000 btime 60000"); // Negative wtime
-        let tm = TimeManagement::from_tokens(tokens, &state, false);
+        let params = parse_test_go("wtime -1000 btime 60000"); // Negative wtime
+        let tm = TimeManagement::from_go(&params, &state, false);
 
         // Since wtime is negative and it's black to move, 'remaining' for black should still be parsed.
         // The negative wtime token will be ignored for black's time.
@@ -497,5 +451,20 @@ mod tests {
         );
         assert_eq!(tm.hard_limit(), Some(expected_hard_limit));
         assert_eq!(tm.node_limit(), usize::MAX);
+    }
+
+    // late endgame positions with moves_left() <= 1 should never divide by 0
+    #[test]
+    fn test_from_go_late_endgame_moves_left_no_panic() {
+        // high fullmove counter causes moves_left() to drop to 0 or 1
+        let late_endgame_fen = "8/8/8/8/8/8/4k3/4K3 w - - 99 200";
+        let state = State::from_fen(late_endgame_fen);
+        assert!(state.moves_left() <= 1);
+
+        let params = parse_test_go("wtime 5000");
+        let tm = TimeManagement::from_go(&params, &state, false);
+
+        assert!(tm.soft_limit().is_some());
+        assert!(tm.hard_limit().is_some());
     }
 }

--- a/src/time_management.rs
+++ b/src/time_management.rs
@@ -100,14 +100,16 @@ impl TimeManagement {
 
             if let Some(m) = params.movestogo {
                 // movestogo is set, use that over moves_left
-                move_time_fraction = (m + 2).min(move_time_fraction).max(1);
+                move_time_fraction = m.saturating_add(2).min(move_time_fraction).max(1);
             }
 
             let r = r.saturating_sub(MOVE_OVERHEAD);
 
             // soft limit: ideal target time for this move
-            let soft_limit = (r + move_time_fraction * increment) / move_time_fraction;
-
+            let total_increment = increment
+                .checked_mul(move_time_fraction)
+                .unwrap_or(Duration::ZERO);
+            let soft_limit = r.checked_add(total_increment).unwrap_or(r) / move_time_fraction;
             // hard limit: safety cap at 1/3 remaining time
             let hard_limit = r / 3;
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -154,11 +154,17 @@ impl Uci {
         };
 
         for mov_str in moves {
+            let mut applied = false;
             for mov in state.available_moves() {
                 if mov.matches_uci(mov_str, self.engine_options.is_chess960) {
                     state.make_move(mov);
+                    applied = true;
                     break;
                 }
+            }
+            if !applied {
+                println!("info string Couldn't parse '{mov_str}' as move");
+                return;
             }
         }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::str::SplitWhitespace;
 
 use crate::engine::Engine;
 use crate::graph;
@@ -10,7 +9,11 @@ use crate::state::{self, State};
 use crate::tablebase;
 use crate::time_management::TimeManagement;
 
-pub type Tokens<'a> = SplitWhitespace<'a>;
+pub mod command;
+pub mod parser;
+
+pub use command::{GoParams, PositionSpec, SetOptionParams, UciCommand};
+pub use parser::ParseError;
 
 const ENGINE_NAME: &str = "Princhess";
 const ENGINE_AUTHOR: &str = "Princess Lana";
@@ -39,6 +42,7 @@ impl Uci {
         }
     }
 
+    // main repl loop reading stdin until quit
     pub fn main_loop(&mut self) {
         let mut next_line: Option<String> = None;
 
@@ -58,66 +62,114 @@ impl Uci {
         }
     }
 
+    // parse line and dispatch uci command
     pub fn handle_command(&mut self, line: &str, is_interactive: bool) -> (bool, Option<String>) {
-        let mut tokens = line.split_whitespace();
+        let command = match UciCommand::parse(line) {
+            Ok(Some(cmd)) => cmd,
+            Ok(None) => return (false, None),
+            Err(ParseError::InvalidPosition | ParseError::InvalidFen) => {
+                println!("info string Couldn't parse '{line}' as position");
+                return (false, None);
+            }
+            Err(ParseError::MissingOptionName | ParseError::MalformedCommand) => {
+                return (false, None);
+            }
+        };
+
+        self.execute(command, is_interactive)
+    }
+
+    // execute parsed uci command
+    pub fn execute(
+        &mut self,
+        command: UciCommand<'_>,
+        is_interactive: bool,
+    ) -> (bool, Option<String>) {
         let mut next_line_from_go = None;
         let mut should_quit = false;
 
-        if let Some(first_word) = tokens.next() {
-            match first_word {
-                "uci" => Self::uci_info(),
-                "isready" => println!("readyok"),
-                "setoption" => self.handle_setoption(tokens),
-                "ucinewgame" => {
-                    self.engine = Engine::new(State::default(), self.engine_options);
-                }
-                "position" => self.handle_position(tokens, line),
-                "quit" => should_quit = true,
-                "go" => {
-                    next_line_from_go = self.handle_go(tokens, is_interactive);
-                }
-                "movelist" => self.engine.print_move_list(tokens),
-                "sizelist" => graph::print_size_list(),
-                "eval" => self.engine.print_eval(),
-                "bench" => self.run_bench(),
-                "randomopen" => self.generate_random_opening(),
-                "fingerprint" => Self::fingerprint(),
-                _ => (),
+        match command {
+            UciCommand::Uci => Self::uci_info(),
+            UciCommand::Debug(_) => (),
+            UciCommand::IsReady => println!("readyok"),
+            UciCommand::SetOption(params) => {
+                self.handle_setoption(params.name, params.value);
             }
+            UciCommand::UciNewGame => {
+                self.engine = Engine::new(State::default(), self.engine_options);
+            }
+            UciCommand::Position { spec, moves } => {
+                self.handle_position(spec, &moves);
+            }
+            UciCommand::Quit => should_quit = true,
+            UciCommand::Stop | UciCommand::PonderHit => (),
+            UciCommand::Go(params) => {
+                next_line_from_go = self.handle_go(&params, is_interactive);
+            }
+            UciCommand::MoveList(moves) => self.engine.print_move_list(&moves),
+            UciCommand::SizeList => graph::print_size_list(),
+            UciCommand::Eval => self.engine.print_eval(),
+            UciCommand::Bench => self.run_bench(),
+            UciCommand::RandomOpen => self.generate_random_opening(),
+            UciCommand::Fingerprint => Self::fingerprint(),
+            UciCommand::UnknownCommand(_) => (),
         }
+
         (should_quit, next_line_from_go)
     }
 
-    fn handle_setoption(&mut self, tokens: Tokens) {
-        if let Some((name, value)) = parse_set_option(tokens) {
+    // handle setoption, clear hash resets ttable and syzygypath updates tb dir
+    fn handle_setoption(&mut self, name: &str, value: Option<&str>) {
+        if name.eq_ignore_ascii_case("clear hash") {
             let root_state = self.engine.root_state().clone();
+            self.engine = Engine::new(root_state, self.engine_options);
+            return;
+        }
 
-            self.options.set(&name, &value);
-            self.engine_options = EngineOptions::from(&self.options);
+        let Some(value) = value else {
+            println!("info string Option '{name}' is not a button and requires a value");
+            return;
+        };
 
-            if name.eq_ignore_ascii_case("syzygypath") {
-                match tablebase::set_tablebase_directory(&value) {
-                    Ok(()) => println!("info string Success initializing tablebase at {value}"),
-                    Err(()) => println!("info string Error initializing tablebase at {value}"),
+        let root_state = self.engine.root_state().clone();
+
+        self.options.set(name, value);
+        self.engine_options = EngineOptions::from(&self.options);
+
+        if name.eq_ignore_ascii_case("syzygypath") {
+            match tablebase::set_tablebase_directory(value) {
+                Ok(()) => println!("info string Success initializing tablebase at {value}"),
+                Err(()) => println!("info string Error initializing tablebase at {value}"),
+            }
+        }
+
+        self.engine = Engine::new(root_state, self.engine_options);
+    }
+
+    // set up root state from startpos/fen and replay moves without allocating
+    fn handle_position(&mut self, spec: PositionSpec<'_>, moves: &[&str]) {
+        let mut state = match spec {
+            PositionSpec::Startpos => State::default(),
+            PositionSpec::Fen(fen) => State::from_fen(fen),
+        };
+
+        for mov_str in moves {
+            for mov in state.available_moves() {
+                if mov.matches_uci(mov_str, self.engine_options.is_chess960) {
+                    state.make_move(mov);
+                    break;
                 }
             }
-
-            self.engine = Engine::new(root_state, self.engine_options);
         }
+
+        self.engine.set_root_state(state);
     }
 
-    fn handle_position(&mut self, tokens: Tokens, line: &str) {
-        if let Some(state) = State::from_tokens(tokens, self.engine_options.is_chess960) {
-            self.engine.set_root_state(state);
-        } else {
-            println!("info string Couldn't parse '{line}' as position");
-        }
+    fn handle_go(&self, params: &GoParams, is_interactive: bool) -> Option<String> {
+        self.engine.go(params, is_interactive)
     }
 
-    fn handle_go(&self, tokens: Tokens, is_interactive: bool) -> Option<String> {
-        self.engine.go(tokens, is_interactive)
-    }
-
+    // run bench across standard fens and spit out nps
     fn run_bench(&mut self) {
         let mut total_nodes = 0;
         let mut total_elapsed_time_ms = 0;
@@ -145,6 +197,7 @@ impl Uci {
         println!("Bench: {total_nodes} nodes {nps} nps");
     }
 
+    // print engine handshake info and available options
     pub fn uci_info() {
         println!("id name {} {}", ENGINE_NAME, VERSION.unwrap_or("unknown"));
         println!("id author {ENGINE_AUTHOR}");
@@ -154,6 +207,7 @@ impl Uci {
         println!("uciok");
     }
 
+    // dump build metadata and neural net hashes
     fn fingerprint() {
         println!(
             "info string git {}",
@@ -174,14 +228,14 @@ impl Uci {
 
     fn generate_random_opening(&mut self) {
         let mut rng = Rng::default();
-        let (moves_played, state) = state::generate_random_opening(&mut rng, 0); // No DFRC
+        let (moves_played, state) = state::generate_random_opening(&mut rng, 0); // no dfrc
 
         let move_strs: Vec<String> = moves_played
             .iter()
             .map(|mv| mv.to_uci(self.engine_options.is_chess960))
             .collect();
 
-        // Set the engine position to the generated opening
+        // point engine at generated opening
         self.engine.set_root_state(state);
 
         println!("info string {}", move_strs.join(" "));
@@ -206,30 +260,3 @@ pub fn read_stdin() -> String {
     input
 }
 
-#[must_use]
-pub fn parse_set_option(mut tokens: Tokens) -> Option<(String, String)> {
-    if tokens.next() != Some("name") {
-        return None;
-    }
-
-    let mut name = tokens.next()?.to_owned();
-
-    for t in tokens.by_ref() {
-        if t == "value" {
-            break;
-        }
-
-        name = format!("{name} {t}");
-    }
-
-    let mut value = None;
-
-    for t in tokens {
-        value = match value {
-            None => Some(t.to_owned()),
-            Some(s) => Some(format!("{s} {t}")),
-        }
-    }
-
-    Some((name, value?))
-}

--- a/src/uci/command.rs
+++ b/src/uci/command.rs
@@ -1,0 +1,56 @@
+use std::time::Duration;
+
+// startpos or raw fen slice from incoming line
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PositionSpec<'a> {
+    Startpos,
+    Fen(&'a str),
+}
+
+// parsed setoption fields, value is None for button types like clear hash
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetOptionParams<'a> {
+    pub name: &'a str,
+    pub value: Option<&'a str>,
+}
+
+// parsed params for go cmd, keep depth/mate/ponder so guis don't freak out but mcts only cares bout time and nodes
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GoParams {
+    pub infinite: bool,
+    pub movetime: Option<Duration>,
+    pub wtime: Option<Duration>,
+    pub btime: Option<Duration>,
+    pub winc: Option<Duration>,
+    pub binc: Option<Duration>,
+    pub movestogo: Option<u32>,
+    pub nodes: Option<usize>,
+    pub depth: Option<u32>,
+    pub mate: Option<u32>,
+    pub ponder: bool,
+}
+
+// all uci commands we care about, borrowing string slices directly from the input buffer
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UciCommand<'a> {
+    Uci,
+    Debug(bool),
+    IsReady,
+    SetOption(SetOptionParams<'a>),
+    UciNewGame,
+    Position {
+        spec: PositionSpec<'a>,
+        moves: Vec<&'a str>,
+    },
+    Go(GoParams),
+    Stop,
+    PonderHit,
+    Quit,
+    MoveList(Vec<&'a str>),
+    SizeList,
+    Eval,
+    Bench,
+    RandomOpen,
+    Fingerprint,
+    UnknownCommand(&'a str),
+}

--- a/src/uci/parser.rs
+++ b/src/uci/parser.rs
@@ -1,0 +1,657 @@
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::time::Duration;
+
+use super::command::{GoParams, PositionSpec, SetOptionParams, UciCommand};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    InvalidPosition,
+    InvalidFen,
+    MissingOptionName,
+    MalformedCommand,
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPosition => write!(f, "invalid position specification"),
+            Self::InvalidFen => {
+                write!(f, "invalid FEN field count (must be between 4 and 6 fields)")
+            }
+            Self::MissingOptionName => write!(f, "missing or malformed setoption name"),
+            Self::MalformedCommand => write!(f, "malformed command arguments"),
+        }
+    }
+}
+
+impl Error for ParseError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenSpan<'a> {
+    pub start: usize,
+    pub end: usize,
+    pub text: &'a str,
+}
+
+// zero-copy tokenizer spitting out byte spans directly over the line
+pub struct Tokenizer<'a> {
+    source: &'a str,
+    indices: std::str::CharIndices<'a>,
+    current_char: Option<(usize, char)>,
+}
+
+impl<'a> Tokenizer<'a> {
+    #[must_use]
+    pub fn new(source: &'a str) -> Self {
+        let mut indices = source.char_indices();
+        let current_char = indices.next();
+        Self {
+            source,
+            indices,
+            current_char,
+        }
+    }
+}
+
+impl<'a> Iterator for Tokenizer<'a> {
+    type Item = TokenSpan<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // skip leading whitespace
+        while let Some((_, ch)) = self.current_char {
+            if !ch.is_whitespace() {
+                break;
+            }
+            self.current_char = self.indices.next();
+        }
+
+        let (start, _) = self.current_char?;
+
+        // find token end
+        while let Some((idx, ch)) = self.indices.next() {
+            if ch.is_whitespace() {
+                self.current_char = Some((idx, ch));
+                return Some(TokenSpan {
+                    start,
+                    end: idx,
+                    text: &self.source[start..idx],
+                });
+            }
+        }
+
+        // reached end of line
+        self.current_char = None;
+        let end = self.source.len();
+        Some(TokenSpan {
+            start,
+            end,
+            text: &self.source[start..end],
+        })
+    }
+}
+
+impl<'a> UciCommand<'a> {
+    // top-level parser dispatching lines into typed commands
+    pub fn parse(line: &'a str) -> Result<Option<Self>, ParseError> {
+        let mut tokens = Tokenizer::new(line);
+        let Some(first) = tokens.next() else {
+            return Ok(None);
+        };
+
+        match first.text {
+            "uci" => Ok(Some(Self::Uci)),
+            "debug" => {
+                let on = match tokens.next().map(|t| t.text) {
+                    Some("on") => true,
+                    Some("off") => false,
+                    _ => return Err(ParseError::MalformedCommand),
+                };
+                Ok(Some(Self::Debug(on)))
+            }
+            "isready" => Ok(Some(Self::IsReady)),
+            "setoption" => parse_setoption(line, &mut tokens).map(Some),
+            "ucinewgame" => Ok(Some(Self::UciNewGame)),
+            "position" => parse_position(line, &mut tokens).map(Some),
+            "quit" => Ok(Some(Self::Quit)),
+            "stop" => Ok(Some(Self::Stop)),
+            "ponderhit" => Ok(Some(Self::PonderHit)),
+            "go" => Ok(Some(Self::Go(parse_go(&mut tokens)))),
+            "movelist" => Ok(Some(Self::MoveList(tokens.map(|t| t.text).collect()))),
+            "sizelist" => Ok(Some(Self::SizeList)),
+            "eval" => Ok(Some(Self::Eval)),
+            "bench" => Ok(Some(Self::Bench)),
+            "randomopen" => Ok(Some(Self::RandomOpen)),
+            "fingerprint" => Ok(Some(Self::Fingerprint)),
+            unknown => Ok(Some(Self::UnknownCommand(unknown))),
+        }
+    }
+}
+
+// parse name and optional value for setoption, buttons got no value field
+pub fn parse_setoption<'a, I>(line: &'a str, tokens: &mut I) -> Result<UciCommand<'a>, ParseError>
+where
+    I: Iterator<Item = TokenSpan<'a>>,
+{
+    let first = tokens.next().ok_or(ParseError::MissingOptionName)?;
+    if !first.text.eq_ignore_ascii_case("name") {
+        return Err(ParseError::MissingOptionName);
+    }
+
+    let mut name_start = None;
+    let mut name_end = 0;
+    let mut value_start = None;
+    let mut value_end = 0;
+    let mut parsing_value = false;
+
+    for t in tokens {
+        if !parsing_value && t.text.eq_ignore_ascii_case("value") {
+            parsing_value = true;
+            continue;
+        }
+
+        if parsing_value {
+            if value_start.is_none() {
+                value_start = Some(t.start);
+            }
+            value_end = t.end;
+        } else {
+            if name_start.is_none() {
+                name_start = Some(t.start);
+            }
+            name_end = t.end;
+        }
+    }
+
+    let name_start = name_start.ok_or(ParseError::MissingOptionName)?;
+    let name = &line[name_start..name_end];
+    let value = if parsing_value {
+        match value_start {
+            Some(start) => Some(&line[start..value_end]),
+            None => Some(""),
+        }
+    } else {
+        None
+    };
+
+    Ok(UciCommand::SetOption(SetOptionParams { name, value }))
+}
+
+// grab startpos or slice raw fen without allocating :)
+pub fn parse_position<'a, I>(line: &'a str, tokens: &mut I) -> Result<UciCommand<'a>, ParseError>
+where
+    I: Iterator<Item = TokenSpan<'a>>,
+{
+    let spec_type = tokens.next().ok_or(ParseError::InvalidPosition)?;
+
+    match spec_type.text {
+        "startpos" => {
+            let moves = match tokens.next() {
+                Some(t) if t.text == "moves" => tokens.map(|t| t.text).collect(),
+                None => Vec::new(),
+                Some(_) => return Err(ParseError::InvalidPosition),
+            };
+            Ok(UciCommand::Position {
+                spec: PositionSpec::Startpos,
+                moves,
+            })
+        }
+        "fen" => {
+            let mut fen_start = None;
+            let mut fen_end = 0;
+            let mut fen_count = 0;
+            let mut has_moves = false;
+
+            for t in tokens.by_ref() {
+                if t.text == "moves" {
+                    has_moves = true;
+                    break;
+                }
+                if fen_count >= 6 {
+                    return Err(ParseError::InvalidFen);
+                }
+                if fen_start.is_none() {
+                    fen_start = Some(t.start);
+                }
+                fen_end = t.end;
+                fen_count += 1;
+            }
+
+            // fen needs 4 to 6 fields or it's bogus
+            if fen_count < 4 || fen_count > 6 {
+                return Err(ParseError::InvalidFen);
+            }
+
+            let fen_start = fen_start.ok_or(ParseError::InvalidFen)?;
+            let fen_str = &line[fen_start..fen_end];
+            let moves = if has_moves {
+                tokens.map(|t| t.text).collect()
+            } else {
+                Vec::new()
+            };
+
+            Ok(UciCommand::Position {
+                spec: PositionSpec::Fen(fen_str),
+                moves,
+            })
+        }
+        _ => Err(ParseError::InvalidPosition),
+    }
+}
+
+// check if token is a go keyword so we don't accidentally consume it as a val
+fn is_go_keyword(s: &str) -> bool {
+    matches!(
+        s,
+        "infinite"
+            | "ponder"
+            | "movetime"
+            | "wtime"
+            | "btime"
+            | "winc"
+            | "binc"
+            | "movestogo"
+            | "nodes"
+            | "depth"
+            | "mate"
+            | "searchmoves"
+    )
+}
+
+// pull out numeric value if next token is a value (not another go keyword)
+fn parse_param_val<'a, T: std::str::FromStr, I>(it: &mut std::iter::Peekable<I>) -> Option<T>
+where
+    I: Iterator<Item = TokenSpan<'a>>,
+{
+    if let Some(next_t) = it.peek() {
+        if is_go_keyword(next_t.text) {
+            return None;
+        }
+    }
+    it.next().and_then(|t| t.text.parse::<T>().ok())
+}
+
+// pull duration in millis if next token is numeric
+fn parse_duration_ms<'a, I>(it: &mut std::iter::Peekable<I>) -> Option<Duration>
+where
+    I: Iterator<Item = TokenSpan<'a>>,
+{
+    parse_param_val::<u64, I>(it).map(Duration::from_millis)
+}
+
+// pull out all time control args and search limits
+pub fn parse_go<'a, I>(tokens: &mut I) -> GoParams
+where
+    I: Iterator<Item = TokenSpan<'a>>,
+{
+    let mut it = tokens.peekable();
+    let mut params = GoParams::default();
+
+    while let Some(t) = it.next() {
+        match t.text {
+            "infinite" => params.infinite = true,
+            "ponder" => params.ponder = true,
+            "movetime" => params.movetime = parse_duration_ms(&mut it),
+            "wtime" => params.wtime = parse_duration_ms(&mut it),
+            "btime" => params.btime = parse_duration_ms(&mut it),
+            "winc" => params.winc = parse_duration_ms(&mut it),
+            "binc" => params.binc = parse_duration_ms(&mut it),
+            "movestogo" => params.movestogo = parse_param_val(&mut it),
+            "nodes" => params.nodes = parse_param_val(&mut it),
+            "depth" => params.depth = parse_param_val(&mut it),
+            "mate" => params.mate = parse_param_val(&mut it),
+            "searchmoves" => {
+                // skip searchmoves move tokens until next keyword
+                while let Some(next_t) = it.peek() {
+                    if is_go_keyword(next_t.text) {
+                        break;
+                    }
+                    it.next();
+                }
+            }
+            _ => (),
+        }
+    }
+
+    params
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_empty() {
+        assert_eq!(UciCommand::parse(""), Ok(None));
+        assert_eq!(UciCommand::parse("   \t  \n"), Ok(None));
+    }
+
+    #[test]
+    fn test_parse_simple_commands() {
+        assert_eq!(UciCommand::parse("uci"), Ok(Some(UciCommand::Uci)));
+        assert_eq!(UciCommand::parse("debug on"), Ok(Some(UciCommand::Debug(true))));
+        assert_eq!(UciCommand::parse("debug off"), Ok(Some(UciCommand::Debug(false))));
+        assert_eq!(UciCommand::parse("isready"), Ok(Some(UciCommand::IsReady)));
+        assert_eq!(
+            UciCommand::parse("ucinewgame"),
+            Ok(Some(UciCommand::UciNewGame))
+        );
+        assert_eq!(UciCommand::parse("quit"), Ok(Some(UciCommand::Quit)));
+        assert_eq!(UciCommand::parse("stop"), Ok(Some(UciCommand::Stop)));
+        assert_eq!(UciCommand::parse("ponderhit"), Ok(Some(UciCommand::PonderHit)));
+        assert_eq!(
+            UciCommand::parse("sizelist"),
+            Ok(Some(UciCommand::SizeList))
+        );
+        assert_eq!(UciCommand::parse("eval"), Ok(Some(UciCommand::Eval)));
+        assert_eq!(UciCommand::parse("bench"), Ok(Some(UciCommand::Bench)));
+        assert_eq!(
+            UciCommand::parse("randomopen"),
+            Ok(Some(UciCommand::RandomOpen))
+        );
+        assert_eq!(
+            UciCommand::parse("fingerprint"),
+            Ok(Some(UciCommand::Fingerprint))
+        );
+    }
+
+    #[test]
+    fn test_parse_setoption() {
+        assert_eq!(
+            UciCommand::parse("setoption name Hash value 256"),
+            Ok(Some(UciCommand::SetOption(SetOptionParams {
+                name: "Hash",
+                value: Some("256"),
+            })))
+        );
+
+        assert_eq!(
+            UciCommand::parse("setoption name Style Select value Solid"),
+            Ok(Some(UciCommand::SetOption(SetOptionParams {
+                name: "Style Select",
+                value: Some("Solid"),
+            })))
+        );
+
+        assert_eq!(
+            UciCommand::parse("setoption name SyzygyPath value /path/to/tablebases with spaces"),
+            Ok(Some(UciCommand::SetOption(SetOptionParams {
+                name: "SyzygyPath",
+                value: Some("/path/to/tablebases with spaces"),
+            })))
+        );
+
+        assert_eq!(
+            UciCommand::parse("setoption name Clear Hash"),
+            Ok(Some(UciCommand::SetOption(SetOptionParams {
+                name: "Clear Hash",
+                value: None,
+            })))
+        );
+
+        assert_eq!(
+            UciCommand::parse("setoption value 128"),
+            Err(ParseError::MissingOptionName)
+        );
+
+        assert_eq!(
+            UciCommand::parse("setoption name"),
+            Err(ParseError::MissingOptionName)
+        );
+
+        // case insensitive keyword test
+        assert_eq!(
+            UciCommand::parse("setoption Name Hash Value 128"),
+            Ok(Some(UciCommand::SetOption(SetOptionParams {
+                name: "Hash",
+                value: Some("128"),
+            })))
+        );
+
+        // empty value string test
+        assert_eq!(
+            UciCommand::parse("setoption name Hash value"),
+            Ok(Some(UciCommand::SetOption(SetOptionParams {
+                name: "Hash",
+                value: Some(""),
+            })))
+        );
+
+        // missing name followed immediately by value
+        assert_eq!(
+            UciCommand::parse("setoption name value 100"),
+            Err(ParseError::MissingOptionName)
+        );
+    }
+
+    #[test]
+    fn test_parse_position() {
+        assert_eq!(
+            UciCommand::parse("position startpos"),
+            Ok(Some(UciCommand::Position {
+                spec: PositionSpec::Startpos,
+                moves: Vec::new(),
+            }))
+        );
+
+        assert_eq!(
+            UciCommand::parse("position startpos moves e2e4 e7e5"),
+            Ok(Some(UciCommand::Position {
+                spec: PositionSpec::Startpos,
+                moves: vec!["e2e4", "e7e5"],
+            }))
+        );
+
+        let fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        let fen_line = format!("position fen {fen}");
+        assert_eq!(
+            UciCommand::parse(&fen_line),
+            Ok(Some(UciCommand::Position {
+                spec: PositionSpec::Fen(fen),
+                moves: Vec::new(),
+            }))
+        );
+
+        let fen_moves_line = format!("position fen {fen} moves e2e4");
+        assert_eq!(
+            UciCommand::parse(&fen_moves_line),
+            Ok(Some(UciCommand::Position {
+                spec: PositionSpec::Fen(fen),
+                moves: vec!["e2e4"],
+            }))
+        );
+
+        let fen_4part = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -";
+        let fen_4part_line = format!("position fen {fen_4part}");
+        assert_eq!(
+            UciCommand::parse(&fen_4part_line),
+            Ok(Some(UciCommand::Position {
+                spec: PositionSpec::Fen(fen_4part),
+                moves: Vec::new(),
+            }))
+        );
+
+        let fen_4part_moves_line = format!("position fen {fen_4part} moves e2e4");
+        assert_eq!(
+            UciCommand::parse(&fen_4part_moves_line),
+            Ok(Some(UciCommand::Position {
+                spec: PositionSpec::Fen(fen_4part),
+                moves: vec!["e2e4"],
+            }))
+        );
+
+        // malformed fen counts (< 4)
+        assert_eq!(
+            UciCommand::parse("position fen 8/8/8 w -"),
+            Err(ParseError::InvalidFen)
+        );
+
+        assert_eq!(
+            UciCommand::parse("position invalid"),
+            Err(ParseError::InvalidPosition)
+        );
+
+        assert_eq!(
+            UciCommand::parse("position startpos invalid e2e4"),
+            Err(ParseError::InvalidPosition)
+        );
+
+        // padded whitespace test
+        assert_eq!(
+            UciCommand::parse("  position   startpos   moves   e2e4  "),
+            Ok(Some(UciCommand::Position {
+                spec: PositionSpec::Startpos,
+                moves: vec!["e2e4"],
+            }))
+        );
+
+        // 7 fields before moves is invalid
+        assert_eq!(
+            UciCommand::parse("position fen 8/8/8/8/8/8/8/8 w - - 0 1 bad_seventh moves e2e4"),
+            Err(ParseError::InvalidFen)
+        );
+
+        // 7 fields without moves is invalid
+        assert_eq!(
+            UciCommand::parse("position fen 8/8/8/8/8/8/8/8 w - - 0 1 bad_seventh"),
+            Err(ParseError::InvalidFen)
+        );
+
+        // missing fen fields before moves is invalid
+        assert_eq!(
+            UciCommand::parse("position fen moves e2e4"),
+            Err(ParseError::InvalidFen)
+        );
+    }
+
+    #[test]
+    fn test_parse_go() {
+        assert_eq!(
+            UciCommand::parse("go wtime 300000 btime 300000 movestogo 40"),
+            Ok(Some(UciCommand::Go(GoParams {
+                wtime: Some(Duration::from_millis(300000)),
+                btime: Some(Duration::from_millis(300000)),
+                movestogo: Some(40),
+                ..GoParams::default()
+            })))
+        );
+
+        assert_eq!(
+            UciCommand::parse("go infinite"),
+            Ok(Some(UciCommand::Go(GoParams {
+                infinite: true,
+                ..GoParams::default()
+            })))
+        );
+
+        assert_eq!(
+            UciCommand::parse("go ponder"),
+            Ok(Some(UciCommand::Go(GoParams {
+                ponder: true,
+                ..GoParams::default()
+            })))
+        );
+
+        assert_eq!(
+            UciCommand::parse("go movetime 10000"),
+            Ok(Some(UciCommand::Go(GoParams {
+                movetime: Some(Duration::from_millis(10000)),
+                ..GoParams::default()
+            })))
+        );
+
+        assert_eq!(
+            UciCommand::parse(
+                "go wtime 30000 btime 20000 winc 1000 binc 500 movestogo 40 nodes 50000 depth 15 mate 3"
+            ),
+            Ok(Some(UciCommand::Go(GoParams {
+                infinite: false,
+                movetime: None,
+                wtime: Some(Duration::from_millis(30000)),
+                btime: Some(Duration::from_millis(20000)),
+                winc: Some(Duration::from_millis(1000)),
+                binc: Some(Duration::from_millis(500)),
+                movestogo: Some(40),
+                nodes: Some(50000),
+                depth: Some(15),
+                mate: Some(3),
+                ponder: false,
+            })))
+        );
+
+        // missing time value followed by keyword shouldn't consume subsequent keyword
+        assert_eq!(
+            UciCommand::parse("go wtime btime 50000"),
+            Ok(Some(UciCommand::Go(GoParams {
+                wtime: None,
+                btime: Some(Duration::from_millis(50000)),
+                ..GoParams::default()
+            })))
+        );
+
+        // negative time value is consumed as invalid value, subsequent keyword parsed
+        assert_eq!(
+            UciCommand::parse("go wtime -1000 btime 60000"),
+            Ok(Some(UciCommand::Go(GoParams {
+                wtime: None,
+                btime: Some(Duration::from_millis(60000)),
+                ..GoParams::default()
+            })))
+        );
+
+        // missing movetime followed by flag
+        assert_eq!(
+            UciCommand::parse("go movetime infinite"),
+            Ok(Some(UciCommand::Go(GoParams {
+                movetime: None,
+                infinite: true,
+                ..GoParams::default()
+            })))
+        );
+
+        // searchmoves skips moves until next keyword
+        assert_eq!(
+            UciCommand::parse("go searchmoves e2e4 e7e5 wtime 30000"),
+            Ok(Some(UciCommand::Go(GoParams {
+                wtime: Some(Duration::from_millis(30000)),
+                ..GoParams::default()
+            })))
+        );
+    }
+
+    #[test]
+    fn test_parse_movelist() {
+        assert_eq!(
+            UciCommand::parse("movelist e2e4 e7e5 g1f3"),
+            Ok(Some(UciCommand::MoveList(vec!["e2e4", "e7e5", "g1f3"])))
+        );
+    }
+
+    #[test]
+    fn test_parse_unknown_command() {
+        assert_eq!(
+            UciCommand::parse("foo bar baz"),
+            Ok(Some(UciCommand::UnknownCommand("foo")))
+        );
+    }
+
+    #[test]
+    fn test_parse_error_display() {
+        assert_eq!(
+            ParseError::InvalidPosition.to_string(),
+            "invalid position specification"
+        );
+        assert_eq!(
+            ParseError::InvalidFen.to_string(),
+            "invalid FEN field count (must be between 4 and 6 fields)"
+        );
+        assert_eq!(
+            ParseError::MissingOptionName.to_string(),
+            "missing or malformed setoption name"
+        );
+        assert_eq!(
+            ParseError::MalformedCommand.to_string(),
+            "malformed command arguments"
+        );
+    }
+}


### PR DESCRIPTION
This PR:-
Rewrites UCI command handling to parse directly from the input buffer without heap allocations.

- **Zero copy UCI parsing:** Slices input directly for moves, FENs, and options. replaces string allocations in move matching with stack byte comparisons (`Move::matches_uci`)
- **Time management safety:** Clamps `move_time_fraction` to `.max(1)` to fix division by zero panics in late endgames, with checked/saturating math to avoid duration overflow
- **Protocol fixes:** Parses `go` params via keyword lookahead so a missing value (e.g. `wtime btime 50000`) does not consume the next keyword, handles valueless button options (`Clear Hash`), enforces 4-6 FEN fields, and bails on illegal move tokens
- **Cleanup:** Decoupled `State` from UCI tokens by removing `pub type Tokens`.

P.S. I hope understanding my comments dont give you a hard time :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more reliable UCI command handling for position setup, search controls, options, and custom engine commands.
  - Added clearer validation and error reporting for malformed commands, FEN positions, options, and moves.
  - Added support for clearing the engine’s hash through the options interface.
  - Added validation for standard, castling, and promotion moves in UCI notation.

- **Bug Fixes**
  - Improved time-control calculations, including safer handling of late endgame positions and edge-case search limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->