### PR TITLE
👌 IMP: Replace flip closures with XOR bitmasks

### DIFF
--- a/src/chess/square.rs
+++ b/src/chess/square.rs
@@ -36,6 +36,9 @@ impl Square {
 
     pub const COUNT: usize = 64;
 
+    pub const FLIP_RANK_MASK: usize = 0x38;
+    pub const FLIP_FILE_MASK: usize = 0x07;
+
     pub fn from_coords(file: File, rank: Rank) -> Square {
         Square((rank.0 * 8) + file.0)
     }
@@ -51,14 +54,6 @@ impl Square {
 
     pub fn file(self) -> File {
         File(self.0 & 7)
-    }
-
-    pub fn flip_rank(self) -> Square {
-        Square(self.0 ^ 0x38)
-    }
-
-    pub fn flip_file(self) -> Square {
-        Square(self.0 ^ 7)
     }
 
     #[must_use]

--- a/src/chess/square.rs
+++ b/src/chess/square.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 use std::hint;
-use std::ops::{Add, BitAnd, Index, IndexMut, Sub};
+use std::ops::{Add, BitAnd, BitXor, Index, IndexMut, Sub};
 
 use crate::chess::Bitboard;
 
@@ -36,8 +36,8 @@ impl Square {
 
     pub const COUNT: usize = 64;
 
-    pub const FLIP_RANK_MASK: usize = 0x38;
-    pub const FLIP_FILE_MASK: usize = 0x07;
+    pub const FLIP_RANK_MASK: u8 = 0x38;
+    pub const FLIP_FILE_MASK: u8 = 0x07;
 
     pub fn from_coords(file: File, rank: Rank) -> Square {
         Square((rank.0 * 8) + file.0)
@@ -174,6 +174,14 @@ impl BitAnd<Bitboard> for Rank {
 
     fn bitand(self, rhs: Bitboard) -> Self::Output {
         Bitboard::from(self) & rhs
+    }
+}
+
+impl BitXor<u8> for Square {
+    type Output = Square;
+
+    fn bitxor(self, rhs: u8) -> Self::Output {
+        Square(self.0 ^ rhs)
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -168,13 +168,13 @@ impl State {
         let stm_ksq = b.king_of(stm);
         let nstm_ksq = b.king_of(!stm);
 
-        let stm_flip = [0, Square::FLIP_RANK_MASK][usize::from(stm == Color::BLACK)]
-            | [0, Square::FLIP_FILE_MASK][usize::from(stm_ksq.file() <= File::D)];
-        let nstm_flip = [0, Square::FLIP_RANK_MASK][usize::from(stm == Color::WHITE)]
-            | [0, Square::FLIP_FILE_MASK][usize::from(nstm_ksq.file() <= File::D)];
+        let stm_flip = [0u8, Square::FLIP_RANK_MASK][usize::from(stm == Color::BLACK)]
+            | [0u8, Square::FLIP_FILE_MASK][usize::from(stm_ksq.file() <= File::D)];
+        let nstm_flip = [0u8, Square::FLIP_RANK_MASK][usize::from(stm == Color::WHITE)]
+            | [0u8, Square::FLIP_FILE_MASK][usize::from(nstm_ksq.file() <= File::D)];
 
-        let stm_king_bucket = Self::king_bucket(Square::from(stm_ksq.index() ^ stm_flip));
-        let nstm_king_bucket = Self::king_bucket(Square::from(nstm_ksq.index() ^ nstm_flip));
+        let stm_king_bucket = Self::king_bucket(stm_ksq ^ stm_flip);
+        let nstm_king_bucket = Self::king_bucket(nstm_ksq ^ nstm_flip);
 
         for sq in b.occupied() {
             let piece = b.piece_at(sq);
@@ -189,7 +189,7 @@ impl State {
             let threat_bucket = usize::from(threatened) * 2 + usize::from(defended);
 
             {
-                let sq_idx = sq.index() ^ stm_flip;
+                let sq_idx = (sq ^ stm_flip).index();
 
                 let bucket = threat_bucket * NUMBER_KING_BUCKETS + stm_king_bucket;
                 let position = [0, 384][side_idx] + piece_idx * 64 + sq_idx;
@@ -199,7 +199,7 @@ impl State {
             }
 
             {
-                let sq_idx = sq.index() ^ nstm_flip;
+                let sq_idx = (sq ^ nstm_flip).index();
 
                 let bucket = threat_bucket * NUMBER_KING_BUCKETS + nstm_king_bucket;
                 let position = [384, 0][side_idx] + piece_idx * 64 + sq_idx;
@@ -218,14 +218,14 @@ impl State {
         let b = &self.board;
         let occ = b.occupied();
 
-        let flip = [0, Square::FLIP_RANK_MASK][usize::from(stm == Color::BLACK)]
-            | [0, Square::FLIP_FILE_MASK][usize::from(b.king_of(stm).file() <= File::D)];
+        let flip = [0u8, Square::FLIP_RANK_MASK][usize::from(stm == Color::BLACK)]
+            | [0u8, Square::FLIP_FILE_MASK][usize::from(b.king_of(stm).file() <= File::D)];
 
         for sq in occ {
             let piece = b.piece_at(sq);
             let color = b.color_at(sq);
 
-            let sq_idx = sq.index() ^ flip;
+            let sq_idx = (sq ^ flip).index();
             let piece_idx = piece.index();
             let side_idx = usize::from(color != stm);
 
@@ -242,14 +242,14 @@ impl State {
         let b = self.board;
         let color = self.side_to_move();
 
-        let flip = [0, Square::FLIP_RANK_MASK][usize::from(color == Color::BLACK)]
-            | [0, Square::FLIP_FILE_MASK][usize::from(b.king_of(color).file() <= File::D)];
+        let flip = [0u8, Square::FLIP_RANK_MASK][usize::from(color == Color::BLACK)]
+            | [0u8, Square::FLIP_FILE_MASK][usize::from(b.king_of(color).file() <= File::D)];
 
         mvs.iter().map(move |mv| {
             let piece = b.piece_at(mv.from());
 
-            let flip_from = Square::from(mv.from().index() ^ flip);
-            let flip_to = Square::from(mv.to().index() ^ flip);
+            let flip_from = mv.from() ^ flip;
+            let flip_to = mv.to() ^ flip;
 
             let adj_to = if mv.is_castle() {
                 flip_to

--- a/src/state.rs
+++ b/src/state.rs
@@ -168,24 +168,10 @@ impl State {
         let stm_ksq = b.king_of(stm);
         let nstm_ksq = b.king_of(!stm);
 
-        let stm_flip = (if stm == Color::BLACK {
-            Square::FLIP_RANK_MASK
-        } else {
-            0
-        }) | (if stm_ksq.file() <= File::D {
-            Square::FLIP_FILE_MASK
-        } else {
-            0
-        });
-        let nstm_flip = (if stm == Color::WHITE {
-            Square::FLIP_RANK_MASK
-        } else {
-            0
-        }) | (if nstm_ksq.file() <= File::D {
-            Square::FLIP_FILE_MASK
-        } else {
-            0
-        });
+        let stm_flip = [0, Square::FLIP_RANK_MASK][usize::from(stm == Color::BLACK)]
+            | [0, Square::FLIP_FILE_MASK][usize::from(stm_ksq.file() <= File::D)];
+        let nstm_flip = [0, Square::FLIP_RANK_MASK][usize::from(stm == Color::WHITE)]
+            | [0, Square::FLIP_FILE_MASK][usize::from(nstm_ksq.file() <= File::D)];
 
         let stm_king_bucket = Self::king_bucket(Square::from(stm_ksq.index() ^ stm_flip));
         let nstm_king_bucket = Self::king_bucket(Square::from(nstm_ksq.index() ^ nstm_flip));
@@ -232,15 +218,8 @@ impl State {
         let b = &self.board;
         let occ = b.occupied();
 
-        let flip = (if stm == Color::BLACK {
-            Square::FLIP_RANK_MASK
-        } else {
-            0
-        }) | (if b.king_of(stm).file() <= File::D {
-            Square::FLIP_FILE_MASK
-        } else {
-            0
-        });
+        let flip = [0, Square::FLIP_RANK_MASK][usize::from(stm == Color::BLACK)]
+            | [0, Square::FLIP_FILE_MASK][usize::from(b.king_of(stm).file() <= File::D)];
 
         for sq in occ {
             let piece = b.piece_at(sq);
@@ -263,15 +242,8 @@ impl State {
         let b = self.board;
         let color = self.side_to_move();
 
-        let flip = (if color == Color::BLACK {
-            Square::FLIP_RANK_MASK
-        } else {
-            0
-        }) | (if b.king_of(color).file() <= File::D {
-            Square::FLIP_FILE_MASK
-        } else {
-            0
-        });
+        let flip = [0, Square::FLIP_RANK_MASK][usize::from(color == Color::BLACK)]
+            | [0, Square::FLIP_FILE_MASK][usize::from(b.king_of(color).file() <= File::D)];
 
         mvs.iter().map(move |mv| {
             let piece = b.piece_at(mv.from());

--- a/src/state.rs
+++ b/src/state.rs
@@ -168,22 +168,27 @@ impl State {
         let stm_ksq = b.king_of(stm);
         let nstm_ksq = b.king_of(!stm);
 
-        let flip_stm = |sq: Square| match (stm == Color::BLACK, stm_ksq.file() <= File::D) {
-            (true, true) => sq.flip_rank().flip_file(),
-            (true, false) => sq.flip_rank(),
-            (false, true) => sq.flip_file(),
-            (false, false) => sq,
-        };
+        let stm_flip = (if stm == Color::BLACK {
+            Square::FLIP_RANK_MASK
+        } else {
+            0
+        }) | (if stm_ksq.file() <= File::D {
+            Square::FLIP_FILE_MASK
+        } else {
+            0
+        });
+        let nstm_flip = (if stm == Color::WHITE {
+            Square::FLIP_RANK_MASK
+        } else {
+            0
+        }) | (if nstm_ksq.file() <= File::D {
+            Square::FLIP_FILE_MASK
+        } else {
+            0
+        });
 
-        let flip_nstm = |sq: Square| match (stm == Color::WHITE, nstm_ksq.file() <= File::D) {
-            (true, true) => sq.flip_rank().flip_file(),
-            (true, false) => sq.flip_rank(),
-            (false, true) => sq.flip_file(),
-            (false, false) => sq,
-        };
-
-        let stm_king_bucket = Self::king_bucket(flip_stm(stm_ksq));
-        let nstm_king_bucket = Self::king_bucket(flip_nstm(nstm_ksq));
+        let stm_king_bucket = Self::king_bucket(Square::from(stm_ksq.index() ^ stm_flip));
+        let nstm_king_bucket = Self::king_bucket(Square::from(nstm_ksq.index() ^ nstm_flip));
 
         for sq in b.occupied() {
             let piece = b.piece_at(sq);
@@ -198,7 +203,7 @@ impl State {
             let threat_bucket = usize::from(threatened) * 2 + usize::from(defended);
 
             {
-                let sq_idx = flip_stm(sq).index();
+                let sq_idx = sq.index() ^ stm_flip;
 
                 let bucket = threat_bucket * NUMBER_KING_BUCKETS + stm_king_bucket;
                 let position = [0, 384][side_idx] + piece_idx * 64 + sq_idx;
@@ -208,7 +213,7 @@ impl State {
             }
 
             {
-                let sq_idx = flip_nstm(sq).index();
+                let sq_idx = sq.index() ^ nstm_flip;
 
                 let bucket = threat_bucket * NUMBER_KING_BUCKETS + nstm_king_bucket;
                 let position = [384, 0][side_idx] + piece_idx * 64 + sq_idx;
@@ -227,18 +232,21 @@ impl State {
         let b = &self.board;
         let occ = b.occupied();
 
-        let flip_square = match (stm == Color::BLACK, b.king_of(stm).file() <= File::D) {
-            (true, true) => |sq: Square| sq.flip_rank().flip_file(),
-            (true, false) => |sq: Square| sq.flip_rank(),
-            (false, true) => |sq: Square| sq.flip_file(),
-            (false, false) => |sq: Square| sq,
-        };
+        let flip = (if stm == Color::BLACK {
+            Square::FLIP_RANK_MASK
+        } else {
+            0
+        }) | (if b.king_of(stm).file() <= File::D {
+            Square::FLIP_FILE_MASK
+        } else {
+            0
+        });
 
         for sq in occ {
             let piece = b.piece_at(sq);
             let color = b.color_at(sq);
 
-            let sq_idx = flip_square(sq).index();
+            let sq_idx = sq.index() ^ flip;
             let piece_idx = piece.index();
             let side_idx = usize::from(color != stm);
 
@@ -255,21 +263,21 @@ impl State {
         let b = self.board;
         let color = self.side_to_move();
 
-        let flip_square = match (color == Color::BLACK, b.king_of(color).file() <= File::D) {
-            (true, true) => |sq: Square| sq.flip_rank().flip_file(),
-            (true, false) => |sq: Square| sq.flip_rank(),
-            (false, true) => |sq: Square| sq.flip_file(),
-            (false, false) => |sq: Square| sq,
-        };
+        let flip = (if color == Color::BLACK {
+            Square::FLIP_RANK_MASK
+        } else {
+            0
+        }) | (if b.king_of(color).file() <= File::D {
+            Square::FLIP_FILE_MASK
+        } else {
+            0
+        });
 
         mvs.iter().map(move |mv| {
             let piece = b.piece_at(mv.from());
 
-            let from_sq = mv.from();
-            let to_sq = mv.to();
-
-            let flip_from = flip_square(from_sq);
-            let flip_to = flip_square(to_sq);
+            let flip_from = Square::from(mv.from().index() ^ flip);
+            let flip_to = Square::from(mv.to().index() ^ flip);
 
             let adj_to = if mv.is_castle() {
                 flip_to


### PR DESCRIPTION
```
-------------------------------------------------
Results of princhess vs princhess-main (8+0.08, 1t, 128MB, UHO_Lichess_4852_v1.epd):
Elo: 5.97 +/- 5.43, nElo: 11.26 +/- 10.24
LOS: 98.44 %, DrawRatio: 53.59 %, PairsRatio: 1.14
Games: 4426, Wins: 1013, Losses: 937, Draws: 2476, Points: 2251.0 (50.86 %)
Ptnml(0-2): [33, 446, 1186, 508, 40], WL/DD Ratio: 0.56
LLR: 2.91 (100.7%) (-2.25, 2.89) [-3.00, 0.00]
--------------------------------------------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated board-orientation handling for values, policies, and move mappings.
  - Preserved side-to-move and king-file symmetry behavior, including castling adjustments.
  - Replaced square-flipping methods with publicly available rank and file transformation masks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->